### PR TITLE
Refactoring removing stutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Needless to say this is a young project. There are things which we know are requ
 
 nedomi is modular. You can add or remove modules from it as much as you want. We've tried to abstarct away every possible thing into an interface. Extending normally is done via writing a package and adding it into its proper place in the source tree and then running `go generate ./...`. For specific instructions you should see the particular README for every type of modules which can be written. They are:
 
-* CacheManager algorithm which takes care of what responses should be cached and how many. See the [README.md](cache/) in `cache/`
+* cache.Manager algorithm which takes care of what responses should be cached and how many. See the [README.md](cache/) in `cache/`
 
 * Storage which decides how exactly cached files will be stored. See [README.md](storage/) in `storage/`
 

--- a/app/app.go
+++ b/app/app.go
@@ -48,9 +48,9 @@ type Application struct {
 	// a handler.RequestHandler.
 	virtualHosts map[string]*vhostPair
 
-	// A map from cache zone ID (from the config) to CacheManager resposible for this
+	// A map from cache zone ID (from the config) to cache.Manager resposible for this
 	// cache zone.
-	cacheManagers map[uint32]cache.CacheManager
+	cacheManagers map[uint32]cache.Manager
 
 	// Channels used to signal Storage objects that files have been evicted from the
 	// cache.
@@ -67,8 +67,8 @@ type vhostPair struct {
 func (a *Application) initFromConfig() error {
 	a.virtualHosts = make(map[string]*vhostPair)
 
-	// cache_zone_id => CacheManager
-	a.cacheManagers = make(map[uint32]cache.CacheManager)
+	// cache_zone_id => cache.Manager
+	a.cacheManagers = make(map[uint32]cache.Manager)
 
 	// cache_zone_id => Storage
 	storages := make(map[uint32]storage.Storage)
@@ -155,7 +155,7 @@ func (a *Application) initFromConfig() error {
 				cacheManagerAlgo = cz.CacheAlgo
 			}
 
-			cm, err := cache.NewCacheManager(cacheManagerAlgo, cz)
+			cm, err := cache.New(cacheManagerAlgo, cz)
 			if err != nil {
 				return err
 			}
@@ -200,7 +200,7 @@ func (a *Application) initFromConfig() error {
 }
 
 // A single goroutine running this function is created for every storage.
-// CacheManagers will send to the com channel files which they wish to be removed
+// cache.Managers will send to the com channel files which they wish to be removed
 // from the storage.
 func (a *Application) cacheToStorageCommunicator(stor storage.Storage,
 	com chan types.ObjectIndex) {

--- a/cache/README.md
+++ b/cache/README.md
@@ -18,7 +18,7 @@ nedomi is very modular when it comes to the cache replacing algorithms. You can 
 It is a subpackage in the `cache/` directory which does to following:
 
 * Has a `New (cz *config.CacheZoneSection) *T` function where `config` is `github.com/ironsmile/nedomi/config`.
-* `T` must conform to the `CacheManager` interface which is defined in [cache/interface.go](interface.go).
+* `T` must conform to the `cache.Manager` interface which is defined in [cache/interface.go](interface.go).
 
 
 ## How to Write Your Own Module?
@@ -27,7 +27,7 @@ You can add your own modules as long as their name does not collide with any oth
 
 * Go into the `cache/` directory - `$ cd .../nedomi/cache`
 * Create a directory which will be the name of your module. Lets say it is **random** so it is `mkdir random`
-* Write your implementation of CacheManager in this directory as `package random`
+* Write your implementation of cache.Manager in this directory as `package random`
 * In the main nedomi directory run `cd .../nedomi && go generate ./...`
 
 
@@ -46,4 +46,4 @@ You can remove any caching module as well. Including the built in modules. Just 
 
 `golang` does not support dynamic linking. So our only choice is to come up with some other trick to have optional modules. We use the `go generate` for this.
 
-At the moment the only way a CacheManager is created in nedomi is through the [NewCacheManager](new_cache_manager.go) function. It looks for CacheManager implementation in the [cacheTypes](types.go) map. This map is generated via `go generate` using the [types.go.template](types.go.template) file as a template.
+At the moment the only way a cache.Manager is created in nedomi is through the [New](new_cache_manager.go) function. It looks for cache.Manager implementation in the [cacheTypes](types.go) map. This map is generated via `go generate` using the [types.go.template](types.go.template) file as a template.

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -15,7 +15,7 @@ func TestCreatingCacheMangers(t *testing.T) {
 		StorageObjects: 9813743,
 	}
 
-	if _, err := NewCacheManager("lru", &cz); err != nil {
+	if _, err := New("lru", &cz); err != nil {
 		t.Errorf("Error when creating cache manager. %s", err)
 	}
 }
@@ -28,7 +28,7 @@ func TestCreatingBogusCacheMangerReturnsError(t *testing.T) {
 		StorageObjects: 9813743,
 	}
 
-	if _, err := NewCacheManager("bogus", &cz); err == nil {
+	if _, err := New("bogus", &cz); err == nil {
 		t.Error("Expected an error when creating bogus manager but got none")
 	}
 }

--- a/cache/interface.go
+++ b/cache/interface.go
@@ -1,4 +1,4 @@
-// Package cache is implements the caching algorithm. It defines the CacheManager
+// Package cache is implements the caching algorithm. It defines the Manager
 // interface. Every CacheZone has its own cache manager. This makes it possible for
 // different caching algorithms to be used in the same time.
 package cache
@@ -8,8 +8,8 @@ import (
 	"github.com/ironsmile/nedomi/types"
 )
 
-// CacheManager interface defines how a cache should behave
-type CacheManager interface {
+// Manager interface defines how a cache should behave
+type Manager interface {
 
 	// Lookup returns wheather this object is in the cache or not
 	Lookup(types.ObjectIndex) bool

--- a/cache/lru/lru.go
+++ b/cache/lru/lru.go
@@ -19,8 +19,8 @@ const (
 	cacheTiers int = 4
 )
 
-// LRUElement is stored in the cache lookup hashmap
-type LRUElement struct {
+// Element is stored in the cache lookup hashmap
+type Element struct {
 	// Pointer to the linked list element
 	ListElem *list.Element
 
@@ -28,12 +28,12 @@ type LRUElement struct {
 	ListTier int
 }
 
-// LRUCache implements segmented LRU Cache. It has cacheTiers segments.
-type LRUCache struct {
+// TieredLRUCache implements segmented LRU Cache. It has cacheTiers segments.
+type TieredLRUCache struct {
 	CacheZone *config.CacheZoneSection
 
 	tiers  [cacheTiers]*list.List
-	lookup map[types.ObjectIndex]*LRUElement
+	lookup map[types.ObjectIndex]*Element
 	mutex  sync.Mutex
 
 	tierListSize int
@@ -46,24 +46,24 @@ type LRUCache struct {
 }
 
 // Lookup implements part of cache.Manager interface
-func (l *LRUCache) Lookup(oi types.ObjectIndex) bool {
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
+func (tc *TieredLRUCache) Lookup(oi types.ObjectIndex) bool {
+	tc.mutex.Lock()
+	defer tc.mutex.Unlock()
 
-	l.requests++
+	tc.requests++
 
-	_, ok := l.lookup[oi]
+	_, ok := tc.lookup[oi]
 
 	if ok {
-		l.hits++
+		tc.hits++
 	}
 
 	return ok
 }
 
 // ShouldKeep implements part of cache.Manager interface
-func (l *LRUCache) ShouldKeep(oi types.ObjectIndex) bool {
-	err := l.AddObject(oi)
+func (tc *TieredLRUCache) ShouldKeep(oi types.ObjectIndex) bool {
+	err := tc.AddObject(oi)
 	if err != nil {
 		log.Printf("Error storing object: %s", err)
 		return true
@@ -72,28 +72,28 @@ func (l *LRUCache) ShouldKeep(oi types.ObjectIndex) bool {
 }
 
 // AddObject implements part of cache.Manager interface
-func (l *LRUCache) AddObject(oi types.ObjectIndex) error {
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
+func (tc *TieredLRUCache) AddObject(oi types.ObjectIndex) error {
+	tc.mutex.Lock()
+	defer tc.mutex.Unlock()
 
-	if _, ok := l.lookup[oi]; ok {
+	if _, ok := tc.lookup[oi]; ok {
 		//!TODO: Create AlreadyInCacheErr type which implements the error interface
 		return fmt.Errorf("Object already in cache: %s", oi)
 	}
 
-	lastList := l.tiers[cacheTiers-1]
+	lastList := tc.tiers[cacheTiers-1]
 
-	if lastList.Len() >= l.tierListSize {
-		l.freeSpaceInLastList()
+	if lastList.Len() >= tc.tierListSize {
+		tc.freeSpaceInLastList()
 	}
 
-	le := &LRUElement{
+	le := &Element{
 		ListTier: cacheTiers - 1,
 		ListElem: lastList.PushFront(oi),
 	}
 
 	log.Printf("Storing %s in cache", oi)
-	l.lookup[oi] = le
+	tc.lookup[oi] = le
 
 	return nil
 }
@@ -101,9 +101,9 @@ func (l *LRUCache) AddObject(oi types.ObjectIndex) error {
 // This function makes space for a new object in a full last list.
 // In case there is space in the upper lists it puts its first element upwards.
 // In case there is not - it removes its last element to make space.
-func (l *LRUCache) freeSpaceInLastList() {
+func (tc *TieredLRUCache) freeSpaceInLastList() {
 	lastListInd := cacheTiers - 1
-	lastList := l.tiers[lastListInd]
+	lastList := tc.tiers[lastListInd]
 
 	if lastList.Len() < 1 {
 		log.Println("Last list is empty but cache is trying to free space in it")
@@ -112,7 +112,7 @@ func (l *LRUCache) freeSpaceInLastList() {
 
 	freeList := -1
 	for i := lastListInd - 1; i >= 0; i-- {
-		if l.tiers[i].Len() < l.tierListSize {
+		if tc.tiers[i].Len() < tc.tierListSize {
 			freeList = i
 			break
 		}
@@ -122,88 +122,88 @@ func (l *LRUCache) freeSpaceInLastList() {
 		// There is a free space upwards in the list tiers. Move every front list
 		// element to the back of the upper tier untill we reach this free slot.
 		for i := lastListInd; i > freeList; i-- {
-			front := l.tiers[i].Front()
+			front := tc.tiers[i].Front()
 			if front == nil {
 				continue
 			}
-			val := l.tiers[i].Remove(front).(types.ObjectIndex)
-			valLruEl, ok := l.lookup[val]
+			val := tc.tiers[i].Remove(front).(types.ObjectIndex)
+			valLruEl, ok := tc.lookup[val]
 			if !ok {
 				log.Printf("ERROR! Object in cache list was not found in the "+
 					" lookup map: %v", val)
 				i++
 				continue
 			}
-			valLruEl.ListElem = l.tiers[i-1].PushBack(val)
+			valLruEl.ListElem = tc.tiers[i-1].PushBack(val)
 		}
 	} else {
 		// There is no free slots anywhere in the upper tiers. So we will have to
 		// remove something from the cache in order to make space.
 		val := lastList.Remove(lastList.Back()).(types.ObjectIndex)
-		l.remove(val)
-		delete(l.lookup, val)
+		tc.remove(val)
+		delete(tc.lookup, val)
 	}
 }
 
-func (l *LRUCache) remove(oi types.ObjectIndex) {
+func (tc *TieredLRUCache) remove(oi types.ObjectIndex) {
 	log.Printf("Removing %s from cache", oi)
-	if l.removeChan == nil {
+	if tc.removeChan == nil {
 		log.Println("Error! LRU cache is trying to write into empty remove channel.")
 		return
 	}
-	l.removeChan <- oi
+	tc.removeChan <- oi
 }
 
 // ReplaceRemoveChannel implements the cache.Manager interface
-func (l *LRUCache) ReplaceRemoveChannel(ch chan<- types.ObjectIndex) {
-	l.removeChan = ch
+func (tc *TieredLRUCache) ReplaceRemoveChannel(ch chan<- types.ObjectIndex) {
+	tc.removeChan = ch
 }
 
 // PromoteObject implements part of cache.Manager interface.
 // It will reorder the linked lists so that this object index will be promoted in
 // rank.
-func (l *LRUCache) PromoteObject(oi types.ObjectIndex) {
+func (tc *TieredLRUCache) PromoteObject(oi types.ObjectIndex) {
 
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
+	tc.mutex.Lock()
+	defer tc.mutex.Unlock()
 
-	lruEl, ok := l.lookup[oi]
+	lruEl, ok := tc.lookup[oi]
 
 	if !ok {
 		// Unlocking the mutex in order to prevent a deadlock while calling
 		// AddObject which tries to lock it too.
-		l.mutex.Unlock()
+		tc.mutex.Unlock()
 
 		// This object is not in the cache yet. So we add it.
-		if err := l.AddObject(oi); err != nil {
+		if err := tc.AddObject(oi); err != nil {
 			log.Printf("Adding object in cache failed. Object: %v\n%s\n", oi, err)
 		}
 
 		// The mutex must be locked because of the deferred Unlock
-		l.mutex.Lock()
+		tc.mutex.Lock()
 		return
 	}
 
 	if lruEl.ListTier == 0 {
 		// This object is in the uppermost tier. It has nowhere to be promoted to
 		// but the front of the tier.
-		if l.tiers[lruEl.ListTier].Front() == lruEl.ListElem {
+		if tc.tiers[lruEl.ListTier].Front() == lruEl.ListElem {
 			return
 		}
-		l.tiers[lruEl.ListTier].MoveToFront(lruEl.ListElem)
+		tc.tiers[lruEl.ListTier].MoveToFront(lruEl.ListElem)
 		return
 	}
 
-	upperTier := l.tiers[lruEl.ListTier-1]
+	upperTier := tc.tiers[lruEl.ListTier-1]
 
 	defer func() {
 		lruEl.ListTier--
 	}()
 
-	if upperTier.Len() < l.tierListSize {
+	if upperTier.Len() < tc.tierListSize {
 		// The upper tier is not yet full. So we can push our object at the end
 		// of it without needing to remove anything from it.
-		l.tiers[lruEl.ListTier].Remove(lruEl.ListElem)
+		tc.tiers[lruEl.ListTier].Remove(lruEl.ListElem)
 		lruEl.ListElem = upperTier.PushFront(oi)
 		return
 	}
@@ -211,49 +211,49 @@ func (l *LRUCache) PromoteObject(oi types.ObjectIndex) {
 	// The upper tier is full. An element from it will be swapped with the one
 	// currently promted.
 	upperListLastOi := upperTier.Remove(upperTier.Back()).(types.ObjectIndex)
-	upperListLastLruEl, ok := l.lookup[upperListLastOi]
+	upperListLastLruEl, ok := tc.lookup[upperListLastOi]
 
 	if !ok {
 		log.Println("ERROR! Cache incosistency. Element from the linked list " +
 			"was not found in the lookup table")
 	} else {
-		upperListLastLruEl.ListElem = l.tiers[lruEl.ListTier].PushFront(upperListLastOi)
+		upperListLastLruEl.ListElem = tc.tiers[lruEl.ListTier].PushFront(upperListLastOi)
 	}
 
-	l.tiers[lruEl.ListTier].Remove(lruEl.ListElem)
+	tc.tiers[lruEl.ListTier].Remove(lruEl.ListElem)
 	lruEl.ListElem = upperTier.PushFront(oi)
 
 }
 
 // ConsumedSize implements part of cache.Manager interface
-func (l *LRUCache) ConsumedSize() config.BytesSize {
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
+func (tc *TieredLRUCache) ConsumedSize() config.BytesSize {
+	tc.mutex.Lock()
+	defer tc.mutex.Unlock()
 
-	return l.consumedSize()
+	return tc.consumedSize()
 }
 
-func (l *LRUCache) consumedSize() config.BytesSize {
+func (tc *TieredLRUCache) consumedSize() config.BytesSize {
 	var sum config.BytesSize
 
 	for i := 0; i < cacheTiers; i++ {
-		sum += (l.CacheZone.PartSize * config.BytesSize(l.tiers[i].Len()))
+		sum += (tc.CacheZone.PartSize * config.BytesSize(tc.tiers[i].Len()))
 	}
 
 	return sum
 }
 
-func (l *LRUCache) init() {
+func (tc *TieredLRUCache) init() {
 	for i := 0; i < cacheTiers; i++ {
-		l.tiers[i] = list.New()
+		tc.tiers[i] = list.New()
 	}
-	l.lookup = make(map[types.ObjectIndex]*LRUElement)
-	l.tierListSize = int(l.CacheZone.StorageObjects / uint64(cacheTiers))
+	tc.lookup = make(map[types.ObjectIndex]*Element)
+	tc.tierListSize = int(tc.CacheZone.StorageObjects / uint64(cacheTiers))
 }
 
-// New returns LRUCache object ready for use.
-func New(cz *config.CacheZoneSection) *LRUCache {
-	lru := &LRUCache{CacheZone: cz}
+// New returns TieredLRUCache object ready for use.
+func New(cz *config.CacheZoneSection) *TieredLRUCache {
+	lru := &TieredLRUCache{CacheZone: cz}
 	lru.init()
 	return lru
 }

--- a/cache/lru/lru.go
+++ b/cache/lru/lru.go
@@ -45,7 +45,7 @@ type LRUCache struct {
 	hits     uint64
 }
 
-// Lookup implements part of CacheManager interface
+// Lookup implements part of cache.Manager interface
 func (l *LRUCache) Lookup(oi ObjectIndex) bool {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
@@ -61,7 +61,7 @@ func (l *LRUCache) Lookup(oi ObjectIndex) bool {
 	return ok
 }
 
-// ShouldKeep implements part of CacheManager interface
+// ShouldKeep implements part of cache.Manager interface
 func (l *LRUCache) ShouldKeep(oi ObjectIndex) bool {
 	err := l.AddObject(oi)
 	if err != nil {
@@ -71,7 +71,7 @@ func (l *LRUCache) ShouldKeep(oi ObjectIndex) bool {
 	return true
 }
 
-// AddObject implements part of CacheManager interface
+// AddObject implements part of cache.Manager interface
 func (l *LRUCache) AddObject(oi ObjectIndex) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
@@ -154,12 +154,12 @@ func (l *LRUCache) remove(oi ObjectIndex) {
 	l.removeChan <- oi
 }
 
-// ReplaceRemoveChannel implements the CacheManager interface
+// ReplaceRemoveChannel implements the cache.Manager interface
 func (l *LRUCache) ReplaceRemoveChannel(ch chan<- ObjectIndex) {
 	l.removeChan = ch
 }
 
-// PromoteObject implements part of CacheManager interface.
+// PromoteObject implements part of cache.Manager interface.
 // It will reorder the linked lists so that this object index will be promoted in
 // rank.
 func (l *LRUCache) PromoteObject(oi ObjectIndex) {
@@ -225,7 +225,7 @@ func (l *LRUCache) PromoteObject(oi ObjectIndex) {
 
 }
 
-// ConsumedSize implements part of CacheManager interface
+// ConsumedSize implements part of cache.Manager interface
 func (l *LRUCache) ConsumedSize() config.BytesSize {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()

--- a/cache/lru/lru_test.go
+++ b/cache/lru/lru_test.go
@@ -27,7 +27,7 @@ func getObjectIndex() types.ObjectIndex {
 	}
 }
 
-func getFullLruCache(t *testing.T) *LRUCache {
+func getFullLruCache(t *testing.T) *TieredLRUCache {
 	cz := getCacheZone()
 	lru := New(cz)
 

--- a/cache/lru/stats.go
+++ b/cache/lru/stats.go
@@ -9,8 +9,8 @@ import (
 	"github.com/ironsmile/nedomi/types"
 )
 
-// LruCacheStats is used by the LRUCache to implement the CacheStats interface.
-type LruCacheStats struct {
+// TieredCacheStats is used by the LRUCache to implement the CacheStats interface.
+type TieredCacheStats struct {
 	id       string
 	hits     uint64
 	requests uint64
@@ -19,7 +19,7 @@ type LruCacheStats struct {
 }
 
 // CacheHitPrc implements part of CacheStats interface
-func (lcs *LruCacheStats) CacheHitPrc() string {
+func (lcs *TieredCacheStats) CacheHitPrc() string {
 	if lcs.requests == 0 {
 		return ""
 	}
@@ -27,48 +27,48 @@ func (lcs *LruCacheStats) CacheHitPrc() string {
 }
 
 // ID implements part of CacheStats interface
-func (lcs *LruCacheStats) ID() string {
+func (lcs *TieredCacheStats) ID() string {
 	return lcs.id
 }
 
 // Hits implements part of CacheStats interface
-func (lcs *LruCacheStats) Hits() uint64 {
+func (lcs *TieredCacheStats) Hits() uint64 {
 	return lcs.hits
 }
 
 // Size implements part of CacheStats interface
-func (lcs *LruCacheStats) Size() config.BytesSize {
+func (lcs *TieredCacheStats) Size() config.BytesSize {
 	return lcs.size
 }
 
 // Objects implements part of CacheStats interface
-func (lcs *LruCacheStats) Objects() uint64 {
+func (lcs *TieredCacheStats) Objects() uint64 {
 	return lcs.objects
 }
 
 // Requests implements part of CacheStats interface
-func (lcs *LruCacheStats) Requests() uint64 {
+func (lcs *TieredCacheStats) Requests() uint64 {
 	return lcs.requests
 }
 
 // Stats implements part of cache.Manager interface
-func (l *LRUCache) Stats() types.CacheStats {
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
+func (tc *TieredLRUCache) Stats() types.CacheStats {
+	tc.mutex.Lock()
+	defer tc.mutex.Unlock()
 
 	var sum config.BytesSize
 	var allObjects uint64
 
 	for i := 0; i < cacheTiers; i++ {
-		objects := config.BytesSize(l.tiers[i].Len())
-		sum += (l.CacheZone.PartSize * objects)
+		objects := config.BytesSize(tc.tiers[i].Len())
+		sum += (tc.CacheZone.PartSize * objects)
 		allObjects += uint64(objects)
 	}
 
-	return &LruCacheStats{
-		id:       l.CacheZone.Path,
-		hits:     l.hits,
-		requests: l.requests,
+	return &TieredCacheStats{
+		id:       tc.CacheZone.Path,
+		hits:     tc.hits,
+		requests: tc.requests,
 		size:     sum,
 		objects:  allObjects,
 	}

--- a/cache/lru/stats.go
+++ b/cache/lru/stats.go
@@ -51,7 +51,7 @@ func (lcs *LruCacheStats) Requests() uint64 {
 	return lcs.requests
 }
 
-// Stats implements part of CacheManager interface
+// Stats implements part of cache.Manager interface
 func (l *LRUCache) Stats() types.CacheStats {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()

--- a/cache/lru/stats_test.go
+++ b/cache/lru/stats_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestStatsPercentsStringRepresentation(t *testing.T) {
-	stats := LruCacheStats{
+	stats := TieredCacheStats{
 		id:       "/nana",
 		hits:     15,
 		requests: 100,

--- a/cache/new_cache_manager.go
+++ b/cache/new_cache_manager.go
@@ -1,7 +1,7 @@
-// This file contains the function which returns a new CacheManager object
+// This file contains the function which returns a new Manager object
 // based on its string name.
 //
-// NewCacheManager uses the cacheTypes map. This map is generated with
+// New uses the cacheTypes map. This map is generated with
 // `go generate` in the types.go file.
 
 //go:generate go run ../tools/module_generator/main.go -template "types.go.template" -output "types.go"
@@ -14,8 +14,8 @@ import (
 	"github.com/ironsmile/nedomi/config"
 )
 
-// NewCacheManager creates and returns a particular type of cache manager.
-func NewCacheManager(ct string, cz *config.CacheZoneSection) (CacheManager, error) {
+// New creates and returns a particular type of cache manager.
+func New(ct string, cz *config.CacheZoneSection) (Manager, error) {
 
 	fnc, ok := cacheTypes[ct]
 
@@ -26,9 +26,9 @@ func NewCacheManager(ct string, cz *config.CacheZoneSection) (CacheManager, erro
 	return fnc(cz), nil
 }
 
-// CacheManagerTypeExists returns true if a CacheManager with this name exists.
+// ManagerTypeExists returns true if a Manager with this name exists.
 // False otherwise.
-func CacheManagerTypeExists(ct string) bool {
+func ManagerTypeExists(ct string) bool {
 	_, ok := cacheTypes[ct]
 	return ok
 }

--- a/cache/types.go
+++ b/cache/types.go
@@ -10,11 +10,11 @@ import (
 	"github.com/ironsmile/nedomi/cache/lru"
 )
 
-type newCacheFunc func(*config.CacheZoneSection) CacheManager
+type newCacheFunc func(*config.CacheZoneSection) Manager
 
 var cacheTypes = map[string]newCacheFunc{
 
-	"lru": func(cz *config.CacheZoneSection) CacheManager {
+	"lru": func(cz *config.CacheZoneSection) Manager {
 		return lru.New(cz)
 	},
 }

--- a/cache/types.go.template
+++ b/cache/types.go.template
@@ -12,12 +12,12 @@ import (
 {{end}}
 )
 
-type newCacheFunc func(*config.CacheZoneSection) CacheManager
+type newCacheFunc func(*config.CacheZoneSection) Manager
 
 var cacheTypes = map[string]newCacheFunc{
 
 {{range .}}
-    "{{.}}": func(cz *config.CacheZoneSection) CacheManager {
+    "{{.}}": func(cz *config.CacheZoneSection) Manager {
         return {{.}}.New(cz)
     },
 {{end}}

--- a/handler/proxy/handler.go
+++ b/handler/proxy/handler.go
@@ -22,9 +22,9 @@ var skippedHeaders = map[string]bool{
 	"Content-Range":     true,
 }
 
-// ProxyHandler is the type resposible for implementing the RequestHandler interface
+// Handler is the type resposible for implementing the RequestHandler interface
 // in this proxy module.
-type ProxyHandler struct {
+type Handler struct {
 }
 
 func shouldSkipHeader(header string) bool {
@@ -35,7 +35,7 @@ func shouldSkipHeader(header string) bool {
 //!TODO: Rewrite Date header
 
 // RequestHandle is the main serving function
-func (ph *ProxyHandler) RequestHandle(writer http.ResponseWriter,
+func (ph *Handler) RequestHandle(writer http.ResponseWriter,
 	req *http.Request, vh *vhost.VirtualHost) {
 
 	log.Printf("[%p] Access %s", req, req.RequestURI)
@@ -50,7 +50,7 @@ func (ph *ProxyHandler) RequestHandle(writer http.ResponseWriter,
 }
 
 // ServerPartialRequest handles serving client requests that have a specified range.
-func (ph *ProxyHandler) ServerPartialRequest(w http.ResponseWriter, r *http.Request,
+func (ph *Handler) ServerPartialRequest(w http.ResponseWriter, r *http.Request,
 	vh *vhost.VirtualHost) {
 	objID := types.ObjectID{CacheKey: vh.CacheKey, Path: r.URL.String()}
 
@@ -120,7 +120,7 @@ func (ph *ProxyHandler) ServerPartialRequest(w http.ResponseWriter, r *http.Requ
 }
 
 // ServeFullRequest handles serving client requests that request the whole file.
-func (ph *ProxyHandler) ServeFullRequest(w http.ResponseWriter, r *http.Request,
+func (ph *Handler) ServeFullRequest(w http.ResponseWriter, r *http.Request,
 	vh *vhost.VirtualHost) {
 	objID := types.ObjectID{CacheKey: vh.CacheKey, Path: r.URL.String()}
 
@@ -155,7 +155,7 @@ func (ph *ProxyHandler) ServeFullRequest(w http.ResponseWriter, r *http.Request,
 
 // ProxyRequest does not use the local storage and directly proxies the
 // request to the upstream server.
-func (ph *ProxyHandler) ProxyRequest(w http.ResponseWriter, r *http.Request,
+func (ph *Handler) ProxyRequest(w http.ResponseWriter, r *http.Request,
 	vh *vhost.VirtualHost) {
 	client := http.Client{}
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
@@ -193,7 +193,7 @@ func (ph *ProxyHandler) ProxyRequest(w http.ResponseWriter, r *http.Request,
 	ph.finishRequest(resp.StatusCode, w, r, resp.Body)
 }
 
-func (ph *ProxyHandler) finishRequest(statusCode int, w http.ResponseWriter,
+func (ph *Handler) finishRequest(statusCode int, w http.ResponseWriter,
 	r *http.Request, responseContents io.Reader) {
 
 	rng := r.Header.Get("Range")
@@ -209,7 +209,7 @@ func (ph *ProxyHandler) finishRequest(statusCode int, w http.ResponseWriter,
 	}
 }
 
-// New creates and returns a ready to used ProxyHandler.
-func New() *ProxyHandler {
-	return &ProxyHandler{}
+// New creates and returns a ready to used Handler.
+func New() *Handler {
+	return &Handler{}
 }

--- a/storage/README.md
+++ b/storage/README.md
@@ -12,7 +12,7 @@ The logic for storing cached files in nedomi is highly modular. At the moment we
 
 It is a subpackage in the `storage/` directory. It follows the follwing rules:
 
-* Has a `func New(cfg config.CacheZoneSection, cm cache.CacheManager, up upstream.Upstream) *T` function.
+* Has a `func New(cfg config.CacheZoneSection, cm cache.Manager, up upstream.Upstream) *T` function.
 
 * `T` must conform to the Storage interface which is defined in [storage/interface.go](interface.go)
 

--- a/storage/disk/impl.go
+++ b/storage/disk/impl.go
@@ -16,7 +16,7 @@ import (
 )
 
 type storageImpl struct {
-	cache          cache.CacheManager
+	cache          cache.Manager
 	partSize       uint64 // actually uint32
 	storageObjects uint64
 	path           string
@@ -29,7 +29,7 @@ type storageImpl struct {
 }
 
 // New returns a new disk storage that ready for use.
-func New(config CacheZoneSection, cm cache.CacheManager,
+func New(config CacheZoneSection, cm cache.Manager,
 	up upstream.Upstream) *storageImpl {
 	storage := &storageImpl{
 		partSize:       config.PartSize.Bytes(),

--- a/storage/new.go
+++ b/storage/new.go
@@ -14,7 +14,7 @@ import (
 
 // New returns a new Storage ready for use. The st argument sets which type of
 // storage will be returned.
-func New(st string, cfg config.CacheZoneSection, cm cache.CacheManager,
+func New(st string, cfg config.CacheZoneSection, cm cache.Manager,
 	up upstream.Upstream) (Storage, error) {
 
 	storFunc, ok := storageTypes[st]

--- a/storage/types.go
+++ b/storage/types.go
@@ -12,12 +12,12 @@ import (
 	"github.com/ironsmile/nedomi/storage/disk"
 )
 
-type newStorageFunc func(cfg config.CacheZoneSection, cm cache.CacheManager,
+type newStorageFunc func(cfg config.CacheZoneSection, cm cache.Manager,
 	up upstream.Upstream) Storage
 
 var storageTypes = map[string]newStorageFunc{
 
-	"disk": func(cfg config.CacheZoneSection, cm cache.CacheManager, up upstream.Upstream) Storage {
+	"disk": func(cfg config.CacheZoneSection, cm cache.Manager, up upstream.Upstream) Storage {
 		return disk.New(cfg, cm, up)
 	},
 }

--- a/storage/types.go.template
+++ b/storage/types.go.template
@@ -14,12 +14,12 @@ import (
 {{end}}
 )
 
-type newStorageFunc func(cfg config.CacheZoneSection, cm cache.CacheManager,
+type newStorageFunc func(cfg config.CacheZoneSection, cm cache.Manager,
 	up upstream.Upstream) Storage
 
 var storageTypes = map[string]newStorageFunc{
 {{range .}}
-	"{{.}}": func(cfg config.CacheZoneSection, cm cache.CacheManager, up upstream.Upstream) Storage {
+	"{{.}}": func(cfg config.CacheZoneSection, cm cache.Manager, up upstream.Upstream) Storage {
 		return {{.}}.New(cfg, cm, up)
 	},
 {{end}}

--- a/upstream/new_upstream.go
+++ b/upstream/new_upstream.go
@@ -26,8 +26,8 @@ func New(upstreamName string, cfg *config.Config) (Upstream, error) {
 	return fnc(cfg), nil
 }
 
-// UpstreamTypeExists returns true if a upstream module with this name exists. False otherwise.
-func UpstreamTypeExists(upstreamName string) bool {
+// TypeExists returns true if a upstream module with this name exists. False otherwise.
+func TypeExists(upstreamName string) bool {
 	_, ok := upstreamTypes[upstreamName]
 	return ok
 }

--- a/upstream/simple/impl.go
+++ b/upstream/simple/impl.go
@@ -8,23 +8,23 @@ import (
 	"github.com/ironsmile/nedomi/config"
 )
 
-// SimpleUpstream is a basic HTTP upstream implementation. It recongizes how to
+// Upstream is a basic HTTP upstream implementation. It recongizes how to
 // make upstream requests by using the virtual host argument.
-type SimpleUpstream struct {
+type Upstream struct {
 	client http.Client
 	cfg    *config.Config
 }
 
-// New returns a configured and ready to use SimpleUpstream instance.
-func New(cfg *config.Config) *SimpleUpstream {
-	return &SimpleUpstream{
+// New returns a configured and ready to use Upstream instance.
+func New(cfg *config.Config) *Upstream {
+	return &Upstream{
 		client: http.Client{},
 		cfg:    cfg,
 	}
 }
 
 // GetRequest executes a simple GET HTTP request to the upstream server.
-func (u *SimpleUpstream) GetRequest(vh *config.VirtualHost, pathStr string) (*http.Response, error) {
+func (u *Upstream) GetRequest(vh *config.VirtualHost, pathStr string) (*http.Response, error) {
 	newURL, err := u.createNewURL(vh, pathStr)
 	if err != nil {
 		return nil, err
@@ -35,7 +35,7 @@ func (u *SimpleUpstream) GetRequest(vh *config.VirtualHost, pathStr string) (*ht
 
 // GetRequestPartial executes a GET HTTP request to the upstream server with a
 // range header, specified by stand and end.
-func (u *SimpleUpstream) GetRequestPartial(vh *config.VirtualHost,
+func (u *Upstream) GetRequestPartial(vh *config.VirtualHost,
 	pathStr string, start, end uint64) (*http.Response, error) {
 	newURL, err := u.createNewURL(vh, pathStr)
 	if err != nil {
@@ -51,7 +51,7 @@ func (u *SimpleUpstream) GetRequestPartial(vh *config.VirtualHost,
 }
 
 // Head executes a HEAD HTTP request to the upstream server.
-func (u *SimpleUpstream) Head(vh *config.VirtualHost, pathStr string) (*http.Response, error) {
+func (u *Upstream) Head(vh *config.VirtualHost, pathStr string) (*http.Response, error) {
 	newURL, err := u.createNewURL(vh, pathStr)
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func (u *SimpleUpstream) Head(vh *config.VirtualHost, pathStr string) (*http.Res
 }
 
 // GetSize retrieves the file size of the specified path from the upstream server.
-func (u *SimpleUpstream) GetSize(vh *config.VirtualHost, pathStr string) (int64, error) {
+func (u *Upstream) GetSize(vh *config.VirtualHost, pathStr string) (int64, error) {
 	resp, err := u.Head(vh, pathStr)
 	if err != nil {
 		return 0, err
@@ -70,7 +70,7 @@ func (u *SimpleUpstream) GetSize(vh *config.VirtualHost, pathStr string) (int64,
 }
 
 // GetHeader retrieves the headers for the specified path from the upstream server.
-func (u *SimpleUpstream) GetHeader(vh *config.VirtualHost, pathStr string) (http.Header, error) {
+func (u *Upstream) GetHeader(vh *config.VirtualHost, pathStr string) (http.Header, error) {
 	resp, err := u.Head(vh, pathStr)
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (u *SimpleUpstream) GetHeader(vh *config.VirtualHost, pathStr string) (http
 	return resp.Header, nil
 }
 
-func (u *SimpleUpstream) createNewURL(vh *config.VirtualHost, pathStr string) (*url.URL, error) {
+func (u *Upstream) createNewURL(vh *config.VirtualHost, pathStr string) (*url.URL, error) {
 	path, err := url.Parse(pathStr)
 	if err != nil {
 		return nil, err

--- a/vhost/virtual_host.go
+++ b/vhost/virtual_host.go
@@ -11,12 +11,12 @@ import (
 // VirtualHost links a config vritual host to its cache manager and a storage object.
 type VirtualHost struct {
 	config.VirtualHost
-	CacheManager cache.CacheManager
+	CacheManager cache.Manager
 	Storage      storage.Storage
 }
 
 // New creates and returns a new VirtualHost struct with the specified parameters.
-func New(config config.VirtualHost, cm cache.CacheManager, storage storage.Storage) *VirtualHost {
+func New(config config.VirtualHost, cm cache.Manager, storage storage.Storage) *VirtualHost {
 	return &VirtualHost{
 		VirtualHost:  config,
 		CacheManager: cm,


### PR DESCRIPTION
Mainly renaming types and methods. All the `thing.ThingStuff` has been eradicated from the code.