### PR TITLE
There is a mutex which protects the storage headers map

### DIFF
--- a/storage/disk/impl.go
+++ b/storage/disk/impl.go
@@ -7,11 +7,12 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"sync"
 	"syscall"
 
 	"github.com/ironsmile/nedomi/cache"
-	. "github.com/ironsmile/nedomi/config"
-	. "github.com/ironsmile/nedomi/types"
+	"github.com/ironsmile/nedomi/config"
+	"github.com/ironsmile/nedomi/types"
 	"github.com/ironsmile/nedomi/upstream"
 )
 
@@ -21,15 +22,20 @@ type storageImpl struct {
 	storageObjects uint64
 	path           string
 	upstream       upstream.Upstream
-	metaHeaders    map[ObjectID]http.Header
 	indexRequests  chan *indexRequest
 	downloaded     chan *indexDownload
-	downloading    map[ObjectIndex]*indexDownload
+	downloading    map[types.ObjectIndex]*indexDownload
 	removeChan     chan removeRequest
+
+	// The headers map must be guarded by a mutex. The storage object
+	// is accessed in different goroutines and possibly threads. Without
+	// the lock strange crashes may happen.
+	metaHeadersLock sync.Mutex
+	metaHeaders     map[types.ObjectID]http.Header
 }
 
 // New returns a new disk storage that ready for use.
-func New(config CacheZoneSection, cm cache.Manager,
+func New(config config.CacheZoneSection, cm cache.Manager,
 	up upstream.Upstream) *storageImpl {
 	storage := &storageImpl{
 		partSize:       config.PartSize.Bytes(),
@@ -37,10 +43,10 @@ func New(config CacheZoneSection, cm cache.Manager,
 		path:           config.Path,
 		cache:          cm,
 		upstream:       up,
-		metaHeaders:    make(map[ObjectID]http.Header),
+		metaHeaders:    make(map[types.ObjectID]http.Header),
 		indexRequests:  make(chan *indexRequest),
 		downloaded:     make(chan *indexDownload),
-		downloading:    make(map[ObjectIndex]*indexDownload),
+		downloading:    make(map[types.ObjectIndex]*indexDownload),
 		removeChan:     make(chan removeRequest),
 	}
 
@@ -49,7 +55,7 @@ func New(config CacheZoneSection, cm cache.Manager,
 	return storage
 }
 
-func (s *storageImpl) downloadIndex(index ObjectIndex, vh *VirtualHost) (*os.File, error) {
+func (s *storageImpl) downloadIndex(index types.ObjectIndex, vh *config.VirtualHost) (*os.File, error) {
 	startOffset := uint64(index.Part) * s.partSize
 	endOffset := startOffset + s.partSize - 1
 	resp, err := s.upstream.GetRequestPartial(vh, index.ObjID.Path, startOffset, endOffset)
@@ -89,7 +95,7 @@ func (s *storageImpl) startDownloadIndex(request *indexRequest) *indexDownload {
 		index:    request.index,
 		requests: []*indexRequest{request},
 	}
-	go func(download *indexDownload, index ObjectIndex, vh *VirtualHost) {
+	go func(download *indexDownload, index types.ObjectIndex, vh *config.VirtualHost) {
 		file, err := s.downloadIndex(index, vh)
 		if err != nil {
 			download.err = err
@@ -103,7 +109,7 @@ func (s *storageImpl) startDownloadIndex(request *indexRequest) *indexDownload {
 
 type indexDownload struct {
 	file     *os.File
-	index    ObjectIndex
+	index    types.ObjectIndex
 	err      error
 	requests []*indexRequest
 }
@@ -163,8 +169,8 @@ func (s *storageImpl) loop() {
 }
 
 type indexRequest struct {
-	index  ObjectIndex
-	vh     *VirtualHost
+	index  types.ObjectIndex
+	vh     *config.VirtualHost
 	reader io.ReadCloser
 	err    error
 	done   chan struct{}
@@ -185,7 +191,7 @@ func (ir *indexRequest) Read(p []byte) (int, error) {
 	return ir.reader.Read(p)
 }
 
-func (s *storageImpl) GetFullFile(vh *VirtualHost, id ObjectID) (io.ReadCloser, error) {
+func (s *storageImpl) GetFullFile(vh *config.VirtualHost, id types.ObjectID) (io.ReadCloser, error) {
 	size, err := s.upstream.GetSize(vh, id.Path)
 	if err != nil {
 		return nil, err
@@ -202,11 +208,22 @@ func (s *storageImpl) GetFullFile(vh *VirtualHost, id ObjectID) (io.ReadCloser, 
 	return s.Get(vh, id, 0, uint64(size))
 }
 
-func (s *storageImpl) Headers(vh *VirtualHost, id ObjectID) (http.Header, error) {
+func (s *storageImpl) Headers(vh *config.VirtualHost, id types.ObjectID) (http.Header, error) {
+
+	s.metaHeadersLock.Lock()
+	defer s.metaHeadersLock.Unlock()
+
 	if headers, ok := s.metaHeaders[id]; ok {
 		return headers, nil
 	}
+
+	// Release the lock for the time of the HTTP request
+	s.metaHeadersLock.Unlock()
 	headers, err := s.upstream.GetHeader(vh, id.Path)
+	// Get the lock back so that the deferred Unlock will not panic or something.
+	// Also we need it in order to add an element to the headers map.
+	s.metaHeadersLock.Lock()
+
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +231,7 @@ func (s *storageImpl) Headers(vh *VirtualHost, id ObjectID) (http.Header, error)
 	return headers, nil
 }
 
-func (s *storageImpl) Get(vh *VirtualHost, id ObjectID, start, end uint64) (io.ReadCloser, error) {
+func (s *storageImpl) Get(vh *config.VirtualHost, id types.ObjectID, start, end uint64) (io.ReadCloser, error) {
 	indexes := s.breakInIndexes(id, start, end)
 	readers := make([]io.ReadCloser, len(indexes))
 	for i, index := range indexes {
@@ -235,21 +252,21 @@ func (s *storageImpl) Get(vh *VirtualHost, id ObjectID, start, end uint64) (io.R
 	return newMultiReadCloser(readers...), nil
 }
 
-func (s *storageImpl) breakInIndexes(id ObjectID, start, end uint64) []ObjectIndex {
+func (s *storageImpl) breakInIndexes(id types.ObjectID, start, end uint64) []types.ObjectIndex {
 	firstIndex := start / s.partSize
 	lastIndex := end/s.partSize + 1
-	result := make([]ObjectIndex, 0, lastIndex-firstIndex)
+	result := make([]types.ObjectIndex, 0, lastIndex-firstIndex)
 	for i := firstIndex; i < lastIndex; i++ {
-		result = append(result, ObjectIndex{id, uint32(i)})
+		result = append(result, types.ObjectIndex{id, uint32(i)})
 	}
 	return result
 }
 
-func (s *storageImpl) pathFromIndex(index ObjectIndex) string {
+func (s *storageImpl) pathFromIndex(index types.ObjectIndex) string {
 	return path.Join(s.pathFromID(index.ObjID), strconv.Itoa(int(index.Part)))
 }
 
-func (s *storageImpl) pathFromID(id ObjectID) string {
+func (s *storageImpl) pathFromID(id types.ObjectID) string {
 	return path.Join(s.path, id.CacheKey, id.Path)
 }
 
@@ -258,7 +275,7 @@ type removeRequest struct {
 	err  chan error
 }
 
-func (s *storageImpl) Discard(id ObjectID) error {
+func (s *storageImpl) Discard(id types.ObjectID) error {
 	request := removeRequest{
 		path: s.pathFromID(id),
 		err:  make(chan error),
@@ -268,7 +285,7 @@ func (s *storageImpl) Discard(id ObjectID) error {
 	return <-request.err
 }
 
-func (s *storageImpl) DiscardIndex(index ObjectIndex) error {
+func (s *storageImpl) DiscardIndex(index types.ObjectIndex) error {
 	request := removeRequest{
 		path: s.pathFromIndex(index),
 		err:  make(chan error),

--- a/storage/disk/impl.go
+++ b/storage/disk/impl.go
@@ -257,7 +257,10 @@ func (s *storageImpl) breakInIndexes(id types.ObjectID, start, end uint64) []typ
 	lastIndex := end/s.partSize + 1
 	result := make([]types.ObjectIndex, 0, lastIndex-firstIndex)
 	for i := firstIndex; i < lastIndex; i++ {
-		result = append(result, types.ObjectIndex{id, uint32(i)})
+		result = append(result, types.ObjectIndex{
+			ObjID: id,
+			Part:  uint32(i),
+		})
 	}
 	return result
 }

--- a/storage/disk/impl_test.go
+++ b/storage/disk/impl_test.go
@@ -1,1 +1,85 @@
 package disk
+
+import (
+	"fmt"
+	"net/http"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/ironsmile/nedomi/config"
+	"github.com/ironsmile/nedomi/types"
+	"github.com/ironsmile/nedomi/upstream"
+)
+
+// Tests the storage headers map in multithreading usage. An error will be
+// triggered by a race condition. This may or may not happen. So no failures
+// in the test do not mean there are no problems. But it may catch an error
+// from time to time. In fact it does quite often for me.
+//
+// Most of the time the test fails with a panic. And most of the time
+// the panic is in the runtime. So isntead of a error message via t.Error
+// the test fails with a panic.
+func TestStorageHeadersFunctionWithManuGoroutines(t *testing.T) {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	httpSrv := &http.Server{
+		Addr:    "127.0.0.1:54231",
+		Handler: &testHandler{},
+	}
+
+	//!TODO: cleanup this webserver
+	go httpSrv.ListenAndServe()
+
+	cz := config.CacheZoneSection{}
+	cz.CacheAlgo = "not-an-algo"
+	cz.PartSize = 1024
+	cz.Path = "/some/path"
+	cz.StorageObjects = 1024
+
+	cm := &cacheManagerMock{}
+
+	// The upstream is not actually using the passed config structure.
+	// For the moment it is safe to give it anything.
+	// Or maybe it would be better to create a mock upstream for testing.
+	up, err := upstream.New("simple", &config.Config{})
+
+	if err != nil {
+		t.Fatalf("Test upstream was not ceated. %s", err)
+	}
+
+	vh := &config.VirtualHost{}
+	vh.UpstreamAddress = "http://127.0.0.1:54231"
+	vh.Verify(make(map[uint32]*config.CacheZoneSection))
+
+	storage := New(cz, cm, up)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+
+		go func(j int) {
+			defer wg.Done()
+
+			// A vain attempt to catch the panic. Most of the times
+			// it is in the runtime goroutine, though.
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Panic in goroutine %d. %s", j, r)
+				}
+			}()
+
+			for i := 0; i < 100; i++ {
+
+				oid := types.ObjectID{}
+				oid.CacheKey = "1"
+				oid.Path = fmt.Sprintf("/%d/%d", i, j)
+
+				storage.Headers(vh, oid)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}

--- a/storage/disk/testing_mocks.go
+++ b/storage/disk/testing_mocks.go
@@ -1,0 +1,52 @@
+package disk
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/ironsmile/nedomi/config"
+	"github.com/ironsmile/nedomi/types"
+)
+
+// Mock cache manager
+
+type cacheManagerMock struct{}
+
+func (c *cacheManagerMock) Lookup(o types.ObjectIndex) bool {
+	return false
+}
+
+func (c *cacheManagerMock) ShouldKeep(o types.ObjectIndex) bool {
+	return false
+}
+
+func (c *cacheManagerMock) AddObject(o types.ObjectIndex) error {
+	return nil
+}
+
+func (c *cacheManagerMock) PromoteObject(o types.ObjectIndex) {}
+
+func (c *cacheManagerMock) ConsumedSize() config.BytesSize {
+	return 0
+}
+
+func (c *cacheManagerMock) ReplaceRemoveChannel(ch chan<- types.ObjectIndex) {
+
+}
+
+func (c *cacheManagerMock) Stats() types.CacheStats {
+	return nil
+}
+
+// Mock http handler
+
+type testHandler struct{}
+
+func (t *testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+	for i := 0; i < 5; i++ {
+		w.Header().Add(fmt.Sprintf("X-Header-%d", i), fmt.Sprintf("value-%d", i))
+	}
+
+	w.WriteHeader(200)
+}


### PR DESCRIPTION
The storage uses a map to hold HTTP headers for all known files kept in the cache.

Previously this map was used without any protection between many goroutines. This lead to occasional crashes.

Also, I've removed some dot imports from the disk implememtation. Maybe it should have been in different commit, but hey!