### PR TITLE
Simplify the initialization of the app and some modules.

### DIFF
--- a/logger/new.go
+++ b/logger/new.go
@@ -12,11 +12,11 @@ import (
 
 // New returns a new Logger ready for use. The lt argument sets which type of
 // logger will be returned.
-func New(lt string, cfg config.LoggerSection) (types.Logger, error) {
-	loggerFunc, ok := loggerTypes[lt]
+func New(cfg config.LoggerSection) (types.Logger, error) {
+	loggerFunc, ok := loggerTypes[cfg.Type]
 
 	if !ok {
-		return nil, fmt.Errorf("No such log type: %s", lt)
+		return nil, fmt.Errorf("No such log type: %s", cfg.Type)
 	}
 
 	return loggerFunc(cfg)

--- a/logger/new_loggers_test.go
+++ b/logger/new_loggers_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestCreatingBogusLogger(t *testing.T) {
-	_, err := New("bogus_logger", config.LoggerSection{})
+	_, err := New(config.LoggerSection{Type: "bogus_logger"})
 
 	if err == nil {
 		t.Error("There was no error when creating bogus logger")

--- a/storage/disk/impl_test.go
+++ b/storage/disk/impl_test.go
@@ -210,7 +210,7 @@ func TestBreakInIndexes(t *testing.T) {
 }
 
 func newStdLogger() types.Logger {
-	l, _ := logger.New("std", config.LoggerSection{
+	l, _ := logger.New(config.LoggerSection{
 		Type:     "std",
 		Settings: []byte(`{"level":"debug"}`),
 	})

--- a/storage/new.go
+++ b/storage/new.go
@@ -19,13 +19,13 @@ import (
 
 // New returns a new Storage ready for use. The st argument sets which type of
 // storage will be returned.
-func New(st string, cfg config.CacheZoneSection, ca types.CacheAlgorithm,
+func New(cfg config.CacheZoneSection, ca types.CacheAlgorithm,
 	log types.Logger) (types.Storage, error) {
 
-	storFunc, ok := storageTypes[st]
+	storFunc, ok := storageTypes[cfg.Type]
 
 	if !ok {
-		return nil, fmt.Errorf("No such storage type: %s", st)
+		return nil, fmt.Errorf("No such storage type: %s", cfg.Type)
 	}
 
 	return storFunc(cfg, ca, log), nil

--- a/storage/new_storages_test.go
+++ b/storage/new_storages_test.go
@@ -8,8 +8,7 @@ import (
 
 func TestCreatingBogusStorage(t *testing.T) {
 	_, err := New(
-		"bogus_storage",
-		config.CacheZoneSection{},
+		config.CacheZoneSection{Type: "bogus_storage"},
 		nil,
 		nil,
 	)

--- a/types/virtual_host.go
+++ b/types/virtual_host.go
@@ -10,4 +10,5 @@ type VirtualHost struct {
 	Storage         Storage
 	UpstreamAddress *url.URL //!TODO: remove, this should not be needed
 	Upstream        Upstream
+	Logger          Logger
 }


### PR DESCRIPTION
This somewhat fixes #37. Also, it fixes a bug, similar to the one from yesterday. Previously, if a cache zone had multiple vhosts and each vhost had it's own custom logger, the logger of the first vhost also became the logger of the cache zone. 

After this fix, the cache zone logger is always the same as the default application logger. In the future we can easily either add the functionality to have custom loggers for each cache zone, or make the cache storage to always use the vhost's logger for each request it handles.