### PR TITLE
move test_helpers in it's old package

### DIFF
--- a/app/env_test.go
+++ b/app/env_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ironsmile/nedomi/config"
 	"github.com/ironsmile/nedomi/utils"
+	"github.com/ironsmile/nedomi/utils/testutils"
 )
 
 // A helper function that returns a full config file that contains the supplied
@@ -25,7 +26,7 @@ func getCfg(sysConfig config.System) *config.Config {
 
 func TestProperEnvironmentCreation(t *testing.T) {
 	t.Parallel()
-	tempDir, cleanup := utils.GetTestFolder(t)
+	tempDir, cleanup := testutils.GetTestFolder(t)
 	defer cleanup()
 
 	tempFile := filepath.Join(tempDir, "test_pid_file.pid")
@@ -129,7 +130,7 @@ func TestWithFullFilesystem(t *testing.T) {
 func TestWithFakeUser(t *testing.T) {
 	t.Parallel()
 
-	tempDir, cleanup := utils.GetTestFolder(t)
+	tempDir, cleanup := testutils.GetTestFolder(t)
 	defer cleanup()
 
 	targetPidFile := filepath.Join(tempDir, "pidfile")
@@ -170,7 +171,7 @@ func TestChangingTheUserWihtNobody(t *testing.T) {
 		}
 	}
 
-	tempDir, cleanup := utils.GetTestFolder(t)
+	tempDir, cleanup := testutils.GetTestFolder(t)
 	defer cleanup()
 
 	targetPidFile := filepath.Join(tempDir, "pidfile")

--- a/handler/cache/old_test.go
+++ b/handler/cache/old_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ironsmile/nedomi/types"
 	"github.com/ironsmile/nedomi/upstream"
 	"github.com/ironsmile/nedomi/utils"
+	"github.com/ironsmile/nedomi/utils/testutils"
 
 	"golang.org/x/net/context"
 
@@ -60,7 +61,7 @@ func setup(t *testing.T) (*http.ServeMux, *types.Location, config.CacheZone, int
 	var err error
 	loc.Logger = newStdLogger()
 
-	path, cleanup := utils.GetTestFolder(t)
+	path, cleanup := testutils.GetTestFolder(t)
 
 	cz := config.CacheZone{
 		ID:             "1",

--- a/storage/disk/impl_test.go
+++ b/storage/disk/impl_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ironsmile/nedomi/config"
 	"github.com/ironsmile/nedomi/logger"
 	"github.com/ironsmile/nedomi/types"
-	"github.com/ironsmile/nedomi/utils"
+	"github.com/ironsmile/nedomi/utils/testutils"
 )
 
 func init() {
@@ -307,7 +307,7 @@ func TestConcurrentSaves(t *testing.T) {
 
 func TestConstructor(t *testing.T) {
 	t.Parallel()
-	workingDiskPath, cleanup := utils.GetTestFolder(t)
+	workingDiskPath, cleanup := testutils.GetTestFolder(t)
 	defer cleanup()
 
 	cfg := &config.CacheZone{Path: workingDiskPath, PartSize: 10}

--- a/storage/disk/utils_test.go
+++ b/storage/disk/utils_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/ironsmile/nedomi/config"
 	"github.com/ironsmile/nedomi/logger"
 	"github.com/ironsmile/nedomi/types"
-	"github.com/ironsmile/nedomi/utils"
+	"github.com/ironsmile/nedomi/utils/testutils"
 )
 
 func getTestDiskStorage(t *testing.T, partSize int) (*Disk, string, func()) {
-	diskPath, cleanup := utils.GetTestFolder(t)
+	diskPath, cleanup := testutils.GetTestFolder(t)
 
 	d, err := New(&config.CacheZone{
 		Path:     diskPath,

--- a/utils/functions_test.go
+++ b/utils/functions_test.go
@@ -4,11 +4,13 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/ironsmile/nedomi/utils/testutils"
 )
 
 func TestFileExistsFunction(t *testing.T) {
 	t.Parallel()
-	tmpDir, cleanup := GetTestFolder(t)
+	tmpDir, cleanup := testutils.GetTestFolder(t)
 	defer cleanup()
 
 	if exists := FileExists(tmpDir); exists {

--- a/utils/testutils/test_helpers.go
+++ b/utils/testutils/test_helpers.go
@@ -1,4 +1,4 @@
-package utils
+package testutils
 
 import (
 	"io/ioutil"


### PR DESCRIPTION
this is required because it imports "testing" which uses "flag" package
to work with cli arguments which are then leaked in nedomi's arguments.