### PR TITLE
Adds an option to start a pprof http listener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.sublime-project
 *.sublime-workspace
 config.developing.json
+nedomi
+

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"runtime"
 	"runtime/pprof"
@@ -22,14 +24,16 @@ const (
 var (
 	testConfig  bool
 	showVersion bool
-	debug       bool
+	pprofHttp   string
 	cpuprofile  string
 )
 
 func init() {
 	flag.BoolVar(&testConfig, "t", false, "Test configuration file and exit")
 	flag.BoolVar(&showVersion, "v", false, "Print version information")
-	flag.BoolVar(&debug, "D", false, "Debug. Will print messages into stdout")
+	flag.StringVar(&pprofHttp, "pprof-http", "",
+		"Address on which wll start the golang's pprof http server. "+
+			"By default it will not be started")
 	flag.StringVar(&cpuprofile, "cpuprofile", "", "Write cpu profile to this file")
 
 	runtime.GOMAXPROCS(runtime.NumCPU())
@@ -37,6 +41,12 @@ func init() {
 
 //!TODO: implement some "unit" tests for this :)
 func run() int {
+	if pprofHttp != "" {
+		go func() {
+			fmt.Println(http.ListenAndServe(pprofHttp, nil))
+		}()
+	}
+
 	if cpuprofile != "" {
 		f, err := os.Create(cpuprofile)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -24,14 +24,14 @@ const (
 var (
 	testConfig  bool
 	showVersion bool
-	pprofHttp   string
+	pprofHTTP   string
 	cpuprofile  string
 )
 
 func init() {
 	flag.BoolVar(&testConfig, "t", false, "Test configuration file and exit")
 	flag.BoolVar(&showVersion, "v", false, "Print version information")
-	flag.StringVar(&pprofHttp, "pprof-http", "",
+	flag.StringVar(&pprofHTTP, "pprof-http", "",
 		"Address on which wll start the golang's pprof http server. "+
 			"By default it will not be started")
 	flag.StringVar(&cpuprofile, "cpuprofile", "", "Write cpu profile to this file")
@@ -41,9 +41,9 @@ func init() {
 
 //!TODO: implement some "unit" tests for this :)
 func run() int {
-	if pprofHttp != "" {
+	if pprofHTTP != "" {
 		go func() {
-			fmt.Println(http.ListenAndServe(pprofHttp, nil))
+			fmt.Println(http.ListenAndServe(pprofHTTP, nil))
 		}()
 	}
 


### PR DESCRIPTION
An command line argument is added which can be used to set an
address on which the http/pprof listener will use. By default
no linstener is started.