### PR TITLE
Feature/configurable default cache time

### DIFF
--- a/app/init.go
+++ b/app/init.go
@@ -166,7 +166,9 @@ func (a *Application) reloadCache(cz *types.CacheZone) {
 			cz.Scheduler.AddEvent(
 				obj.ID.Hash(),
 				storage.GetExpirationHandler(cz, a.logger, obj.ID),
-				1*time.Hour, //TODO: remove hardcoded time, get it from the saved metadata or headers
+				//!TODO: Maybe do not use time.Now but cached time. See the todo comment
+				// in utils.IsMetadataFresh.
+				time.Unix(obj.ExpiresAt, 0).Sub(time.Now()),
 			)
 
 			for _, idx := range parts {

--- a/config.example.json
+++ b/config.example.json
@@ -53,7 +53,12 @@
                 "cache_zone": "zone2",
                 "cache_key": "1.2",
                 "cache_key_includes_query": true,
-                "cache_default_duration": "168h"
+                "cache_default_duration": "7h",
+                "locations": {
+                    "/nana": {
+                        "cache_default_duration": "168h"
+                    }
+                }
             },
             "127.0.0.2": {
                 "aliases": [

--- a/config.example.json
+++ b/config.example.json
@@ -52,7 +52,8 @@
                 "upstream_address": "http://localhost",
                 "cache_zone": "zone2",
                 "cache_key": "1.2",
-                "cache_key_includes_query": true
+                "cache_key_includes_query": true,
+                "cache_default_duration": "168h"
             },
             "127.0.0.2": {
                 "aliases": [

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -106,8 +106,11 @@ func TestConfigVerification(t *testing.T) {
 		"No error with wrong user directive": func(cfg *Config) {
 			cfg.System.User = "no-existing-user-please"
 		},
-		"No error with wrong cache default duration": func(cfg *Config) {
+		"No error with wrong cache default duration in location": func(cfg *Config) {
 			cfg.HTTP.Servers[0].Locations[0].CacheDefaultDuration = -1 * time.Hour
+		},
+		"No error with wrong cache default duration in vhost": func(cfg *Config) {
+			cfg.HTTP.Servers[0].CacheDefaultDuration = -1 * time.Hour
 		},
 	}
 

--- a/config/section_location.go
+++ b/config/section_location.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"time"
 )
 
 // baseLocation contains the basic configuration options for virtual host's. location.
@@ -13,6 +14,7 @@ type baseLocation struct {
 	UpstreamAddress       string    `json:"upstream_address"`
 	CacheZone             string    `json:"cache_zone"`
 	CacheKey              string    `json:"cache_key"`
+	CacheDefaultDuration  string    `json:"cache_default_duration"`
 	Handlers              []Handler `json:"handlers"`
 	Logger                Logger    `json:"logger"`
 	CacheKeyIncludesQuery bool      `json:"cache_key_includes_query"`
@@ -21,9 +23,10 @@ type baseLocation struct {
 // Location contains all configuration options for virtual host's location.
 type Location struct {
 	baseLocation
-	UpstreamAddress *url.URL   `json:"upstream_address"`
-	CacheZone       *CacheZone `json:"cache_zone"`
-	parent          *VirtualHost
+	UpstreamAddress      *url.URL      `json:"upstream_address"`
+	CacheZone            *CacheZone    `json:"cache_zone"`
+	CacheDefaultDuration time.Duration `json:"cache_default_duration"`
+	parent               *VirtualHost
 }
 
 // UnmarshalJSON is a custom JSON unmashalling that also implements inheritance
@@ -33,6 +36,18 @@ func (ls *Location) UnmarshalJSON(buff []byte) error {
 	if err := json.Unmarshal(buff, &ls.baseLocation); err != nil {
 		return err
 	}
+
+	// Convert the location string to time.Duration
+	if ls.baseLocation.CacheDefaultDuration == "" {
+		//!TODO: maybe add HTTPSection-wide configuration option for default caching duration
+		// and use it here instead of this hardcoded time.
+		ls.CacheDefaultDuration = time.Hour
+	} else if dur, err := time.ParseDuration(ls.baseLocation.CacheDefaultDuration); err != nil {
+		return fmt.Errorf("Error parsing %s's cache_default_location: %s", ls, err)
+	} else {
+		ls.CacheDefaultDuration = dur
+	}
+
 	// Convert the upstream URL from string to url.URL
 	if ls.baseLocation.UpstreamAddress != "" {
 		parsed, err := url.Parse(ls.baseLocation.UpstreamAddress)
@@ -46,13 +61,14 @@ func (ls *Location) UnmarshalJSON(buff []byte) error {
 	if cz, ok := ls.parent.parent.parent.CacheZones[ls.baseLocation.CacheZone]; ok {
 		ls.CacheZone = cz
 	} else {
-		return fmt.Errorf("Location %s has an invalid cache zone %s", ls, ls.CacheZone.ID)
+		return fmt.Errorf("Location %s has an invalid cache zone `%s`", ls,
+			ls.baseLocation.CacheZone)
 	}
 
 	return nil
 }
 
-// Validate checks the virtual host config for logical errors.
+// Validate checks the virtual host location config for logical errors.
 func (ls *Location) Validate() error {
 	if ls.Name == "" {
 		return fmt.Errorf("All locations should have a match setting")
@@ -60,6 +76,10 @@ func (ls *Location) Validate() error {
 
 	if len(ls.Handlers) == 0 {
 		return fmt.Errorf("Missing handlers for location %s", ls)
+	}
+
+	if ls.CacheDefaultDuration <= 0 {
+		return fmt.Errorf("Cache default duration in %s must be positive", ls)
 	}
 
 	return nil

--- a/config/section_location.go
+++ b/config/section_location.go
@@ -39,9 +39,15 @@ func (ls *Location) UnmarshalJSON(buff []byte) error {
 
 	// Convert the location string to time.Duration
 	if ls.baseLocation.CacheDefaultDuration == "" {
-		//!TODO: maybe add HTTPSection-wide configuration option for default caching duration
-		// and use it here instead of this hardcoded time.
-		ls.CacheDefaultDuration = time.Hour
+		if ls.parent != nil {
+			// Inject the CacheDefaultDuration from the location's parent
+			ls.CacheDefaultDuration = ls.parent.CacheDefaultDuration
+		} else {
+			//!TODO: maybe add HTTPSection-wide configuration option for default caching duration
+			// and use it here instead of this hardcoded time.
+			ls.CacheDefaultDuration = DefaultCacheDuration
+		}
+
 	} else if dur, err := time.ParseDuration(ls.baseLocation.CacheDefaultDuration); err != nil {
 		return fmt.Errorf("Error parsing %s's cache_default_location: %s", ls, err)
 	} else {

--- a/config/section_location_test.go
+++ b/config/section_location_test.go
@@ -66,7 +66,7 @@ var defaultDurtaionMatrix = []struct {
 		`,
 		unmarshallable: true,
 		verifyOK:       true,
-		duration:       time.Hour, //!TODO: change this when this default is configurable
+		duration:       2 * DefaultCacheDuration, //!TODO: change this when this is configurable
 	}, {
 		sectionString: `
 			{
@@ -131,6 +131,10 @@ func newLocForTesting() *Location {
 
 	// Potentionally a panic
 	cfg.CacheZones["default"] = nil
+
+	//!TODO: This is hardcoded to the same value as the one in the JSON Unmarshalling in
+	// the vhost section.
+	loc.parent.CacheDefaultDuration = 2 * DefaultCacheDuration
 
 	return loc
 }

--- a/config/section_location_test.go
+++ b/config/section_location_test.go
@@ -1,0 +1,136 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLocationJSONUnmarshallingValidLocation(t *testing.T) {
+	loc := newLocForTesting()
+
+	err := loc.UnmarshalJSON([]byte(`
+		{
+			"upstream_address": "http://example.com",
+			"cache_zone": "default",
+			"handlers": [{"type": "status"}]
+		}
+	`))
+
+	if err != nil {
+		t.Errorf("Error while json unmrashalling working location: %s", err)
+	}
+}
+
+var defaultDurtaionMatrix = []struct {
+	sectionString  string
+	unmarshallable bool
+	verifyOK       bool
+	duration       time.Duration
+}{
+	{
+		sectionString: `
+			{
+				"upstream_address": "http://example.com",
+				"handlers": [{"type": "cache"}],
+				"cache_zone": "default",
+				"cache_key": "1.1",
+				"cache_default_duration": "3h",
+				"cache_key_includes_query": true
+			}
+		`,
+		unmarshallable: true,
+		verifyOK:       true,
+		duration:       3 * time.Hour,
+	}, {
+		sectionString: `
+			{
+				"upstream_address": "http://example.com",
+				"handlers": [{"type": "cache"}],
+				"cache_zone": "default",
+				"cache_key": "1.1",
+				"cache_default_duration": "baba",
+				"cache_key_includes_query": true
+			}
+		`,
+		unmarshallable: false,
+		verifyOK:       false,
+	}, {
+		sectionString: `
+			{
+				"upstream_address": "http://example.com",
+				"handlers": [{"type": "cache"}],
+				"cache_zone": "default",
+				"cache_key": "1.1",
+				"cache_key_includes_query": true
+			}
+		`,
+		unmarshallable: true,
+		verifyOK:       true,
+		duration:       time.Hour, //!TODO: change this when this default is configurable
+	}, {
+		sectionString: `
+			{
+				"upstream_address": "http://example.com",
+				"handlers": [{"type": "cache"}],
+				"cache_zone": "default",
+				"cache_key": "1.1",
+				"cache_default_duration": "-5h",
+				"cache_key_includes_query": true
+			}
+		`,
+		unmarshallable: true,
+		verifyOK:       false,
+	},
+}
+
+func TestLocationJSONUnmarshallingAndVeirfyingCacheDefaultDuration(t *testing.T) {
+	for index, test := range defaultDurtaionMatrix {
+		loc := newLocForTesting()
+		err := loc.UnmarshalJSON([]byte(test.sectionString))
+		if test.unmarshallable && err != nil {
+			t.Errorf("Error while unmarshalling working config %d: %s", index, err)
+		} else if !test.unmarshallable && err == nil {
+			t.Errorf("No error while unmarshalling broken working config %d", index)
+		}
+
+		if !test.unmarshallable {
+			continue
+		}
+
+		err = loc.Validate()
+
+		if test.verifyOK && err != nil {
+			t.Errorf("Error while verifying working config %d: %s", index, err)
+		}
+
+		if !test.verifyOK && err == nil {
+			t.Errorf("No error while verifying broken config %d: %s", index, err)
+		}
+
+		if !test.verifyOK {
+			continue
+		}
+
+		if test.duration != loc.CacheDefaultDuration {
+			t.Errorf("Expected default cache duration of %s but got: %s",
+				test.duration, loc.CacheDefaultDuration)
+		}
+	}
+}
+
+func newLocForTesting() *Location {
+	loc := new(Location)
+	cfg := &Config{
+		CacheZones: make(map[string]*CacheZone),
+	}
+
+	loc.Name = "/baba"
+	loc.parent = &VirtualHost{}
+	loc.parent.parent = &HTTP{}
+	loc.parent.parent.parent = cfg
+
+	// Potentionally a panic
+	cfg.CacheZones["default"] = nil
+
+	return loc
+}

--- a/handler/cache/handler.go
+++ b/handler/cache/handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ironsmile/nedomi/types"
 	"github.com/ironsmile/nedomi/utils"
+	"github.com/ironsmile/nedomi/utils/cacheutils"
 )
 
 // reqHandler handles an individual request (so we don't have to pass a lot of
@@ -46,7 +47,7 @@ func (h *reqHandler) handle() {
 			h.Logger.Errorf("[%p] Storage error when discarding of object's data: %s", h.req, discardErr)
 		}
 		h.carbonCopyProxy()
-	} else if !utils.CacheSatisfiesRequest(obj, h.req) {
+	} else if !cacheutils.CacheSatisfiesRequest(obj, h.req) {
 		h.Logger.Debugf("[%p] Client does not want cached response or the cache does not satisfy the request, proxying...", h.req)
 		h.carbonCopyProxy()
 	} else {

--- a/handler/cache/handler_helpers.go
+++ b/handler/cache/handler_helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ironsmile/nedomi/storage"
 	"github.com/ironsmile/nedomi/types"
 	"github.com/ironsmile/nedomi/utils"
+	"github.com/ironsmile/nedomi/utils/cacheutils"
 )
 
 // Hop-by-hop headers. These are removed when sent to the client.
@@ -78,7 +79,7 @@ func (h *reqHandler) getResponseHook() func(*utils.FlexibleResponseWriter) {
 		h.Logger.Debugf("[%p] Received headers for %s, sending them to client...", h.req, h.req.URL)
 		utils.CopyHeadersWithout(rw.Headers, h.resp.Header(), hopHeaders...)
 		h.resp.WriteHeader(rw.Code)
-		isCacheable, expiresIn := utils.IsResponseCacheable(rw.Code, rw.Headers)
+		isCacheable, expiresIn := cacheutils.IsResponseCacheable(rw.Code, rw.Headers)
 		responseRange, err := h.getResponseRange(rw.Code, rw.Headers)
 		if !isCacheable || err != nil || 0 > expiresIn {
 			h.Logger.Debugf("[%p] Response is non-cacheable (%s) :(", h.req, err)

--- a/handler/cache/handler_helpers.go
+++ b/handler/cache/handler_helpers.go
@@ -87,7 +87,7 @@ func (h *reqHandler) getResponseHook() func(*utils.FlexibleResponseWriter) {
 			return
 		}
 
-		expiresIn := cacheutils.ResponseExpiresIn(rw.Headers, time.Hour)
+		expiresIn := cacheutils.ResponseExpiresIn(rw.Headers, h.CacheDefaultDuration)
 		if 0 > expiresIn {
 			h.Logger.Debugf("[%p] Response expires in the past: %s", h.req, expiresIn)
 			rw.BodyWriter = h.resp

--- a/handler/cache/handler_helpers.go
+++ b/handler/cache/handler_helpers.go
@@ -109,12 +109,16 @@ func (h *reqHandler) getResponseHook() func(*utils.FlexibleResponseWriter) {
 			code = http.StatusOK
 		}
 
+		//!TODO: maybe call cached time.Now. See the comment in utils.IsMetadataFresh
+		now := time.Now()
+
 		obj := &types.ObjectMetadata{
 			ID:                h.objID,
-			ResponseTimestamp: time.Now().Unix(),
+			ResponseTimestamp: now.Unix(),
 			Code:              code,
 			Size:              responseRange.ObjSize,
 			Headers:           make(http.Header),
+			ExpiresAt:         now.Add(expiresIn).Unix(),
 		}
 		utils.CopyHeadersWithout(rw.Headers, obj.Headers, metadataHeadersToFilter...)
 

--- a/types/location.go
+++ b/types/location.go
@@ -1,16 +1,20 @@
 package types
 
-import "net/url"
+import (
+	"net/url"
+	"time"
+)
 
 // Location links a config location to its cache algorithm and a storage object.
 type Location struct {
 	Name                  string
-	CacheKey              string
 	Handler               RequestHandler
-	Cache                 *CacheZone //!TODO: this and the one below should be part of the cache handler settings
+	CacheKey              string
+	CacheDefaultDuration  time.Duration
+	CacheKeyIncludesQuery bool
+	Cache                 *CacheZone //!TODO: this should be part of the cache handler settings
 	Upstream              Upstream
 	Logger                Logger
-	CacheKeyIncludesQuery bool
 }
 
 func (l *Location) String() string {

--- a/types/object_metadata.go
+++ b/types/object_metadata.go
@@ -1,12 +1,31 @@
 package types
 
-import "net/http"
+import (
+	"net/http"
+)
 
 // ObjectMetadata represents all the needed metadata of a cacheable object.
 type ObjectMetadata struct {
-	ID                *ObjectID
+
+	// The ObjectID for this file. It is used for identifying the object throughout
+	// the cache layers in nedomi.
+	ID *ObjectID
+
+	// The time of the first request/response for this object as unix timestamp.
 	ResponseTimestamp int64
-	Code              int
-	Size              uint64
-	Headers           http.Header
+
+	// Status code of the first proxied response for this object.
+	Code int
+
+	// The object size in bytes. Normally this should correspond to the
+	// upstream's Content-Length header.
+	Size uint64
+
+	// HTTP headers which were received from the upstream and which we should
+	// pass down for this object for any subsequent request.
+	Headers http.Header
+
+	// The time at wich this object can be considered stale. After this time
+	// the object must be revalidated or discarded. This value is a unix timestamp.
+	ExpiresAt int64
 }

--- a/utils/cacheutils/cachable.go
+++ b/utils/cacheutils/cachable.go
@@ -1,0 +1,66 @@
+package cacheutils
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ironsmile/nedomi/types"
+	"github.com/pquerna/cachecontrol/cacheobject"
+)
+
+// CacheSatisfiesRequest returs whether the client allows the requested content
+// to be retrieved from the cache and whether the cache we have is fresh enough
+// to be used for handling the request.
+func CacheSatisfiesRequest(obj *types.ObjectMetadata, req *http.Request) bool {
+	//!TODO: improve; implement something like github.com/pquerna/cachecontrol but better
+	//!TODO: write unit tests
+
+	//!TODO: handle cases with respect to https://tools.ietf.org/html/rfc7232
+
+	reqDir, _ := cacheobject.ParseRequestCacheControl(req.Header.Get("Cache-Control"))
+	return !(reqDir.NoCache || reqDir.NoStore)
+}
+
+// IsResponseCacheable returs whether the upstream server allows the requested
+// content to be saved in the cache. True result and 0 duration means that the
+// response has no expiry date.
+func IsResponseCacheable(code int, headers http.Header) (bool, time.Duration) {
+	//!TODO: write a better custom implementation or fork the cacheobject - the API sucks
+	//!TODO: correctly handle cache-control, pragma, etag and vary headers
+	//!TODO: write unit tests
+
+	if code != http.StatusOK && code != http.StatusPartialContent {
+		return false, 0
+	}
+
+	// For now, we do not cache encoded responses
+	if headers.Get("Content-Encoding") != "" {
+		return false, 0
+	}
+
+	// We do not cache multipart range responses
+	if strings.Contains(headers.Get("Content-Type"), "multipart/byteranges") {
+		return false, 0
+	}
+
+	respDir, err := cacheobject.ParseResponseCacheControl(headers.Get("Cache-Control"))
+	if err != nil || respDir.NoCachePresent || respDir.NoStore || respDir.PrivatePresent {
+		return false, 0
+	}
+
+	expiresIn := 1 * time.Hour //!TODO: make configurable
+	if respDir.SMaxAge > 0 {
+		expiresIn = time.Duration(respDir.SMaxAge) * time.Second
+	} else if respDir.MaxAge > 0 {
+		expiresIn = time.Duration(respDir.MaxAge) * time.Second
+	} else if headers.Get("Expires") != "" {
+		_ = "breakpoint"
+		if t, err := time.Parse(time.RFC1123, headers.Get("Expires")); err == nil {
+			//!TODO: use the server time from the Date header to calculate?
+			expiresIn = t.Sub(time.Now())
+		}
+	}
+
+	return true, expiresIn
+}

--- a/utils/cacheutils/cachable.go
+++ b/utils/cacheutils/cachable.go
@@ -52,7 +52,6 @@ func IsResponseCacheable(code int, headers http.Header) bool {
 	return true
 }
 
-
 // ResponseExpiresIn parses the expiration time from upstream headers, if any, and returns
 // it as a duration from now. If no expire time is found, it returns its second argument:
 // the default expiration time.

--- a/utils/cacheutils/cachable.go
+++ b/utils/cacheutils/cachable.go
@@ -25,42 +25,58 @@ func CacheSatisfiesRequest(obj *types.ObjectMetadata, req *http.Request) bool {
 // IsResponseCacheable returs whether the upstream server allows the requested
 // content to be saved in the cache. True result and 0 duration means that the
 // response has no expiry date.
-func IsResponseCacheable(code int, headers http.Header) (bool, time.Duration) {
+func IsResponseCacheable(code int, headers http.Header) bool {
 	//!TODO: write a better custom implementation or fork the cacheobject - the API sucks
 	//!TODO: correctly handle cache-control, pragma, etag and vary headers
 	//!TODO: write unit tests
 
 	if code != http.StatusOK && code != http.StatusPartialContent {
-		return false, 0
+		return false
 	}
 
 	// For now, we do not cache encoded responses
 	if headers.Get("Content-Encoding") != "" {
-		return false, 0
+		return false
 	}
 
 	// We do not cache multipart range responses
 	if strings.Contains(headers.Get("Content-Type"), "multipart/byteranges") {
-		return false, 0
+		return false
 	}
 
 	respDir, err := cacheobject.ParseResponseCacheControl(headers.Get("Cache-Control"))
 	if err != nil || respDir.NoCachePresent || respDir.NoStore || respDir.PrivatePresent {
-		return false, 0
+		return false
 	}
 
-	expiresIn := 1 * time.Hour //!TODO: make configurable
+	return true
+}
+
+
+// ResponseExpiresIn parses the expiration time from upstream headers, if any, and returns
+// it as a duration from now. If no expire time is found, it returns its second argument:
+// the default expiration time.
+func ResponseExpiresIn(headers http.Header, ifNotAny time.Duration) time.Duration {
+
+	//!TODO: this cacheobject.ParseResponseCacheControl is called two times for every
+	// caceable response. We should find a way not to duplicate work. Maybe pass the resout
+	// around somehow?
+	respDir, err := cacheobject.ParseResponseCacheControl(headers.Get("Cache-Control"))
+	if err != nil {
+		return ifNotAny
+	}
+
 	if respDir.SMaxAge > 0 {
-		expiresIn = time.Duration(respDir.SMaxAge) * time.Second
+		return time.Duration(respDir.SMaxAge) * time.Second
 	} else if respDir.MaxAge > 0 {
-		expiresIn = time.Duration(respDir.MaxAge) * time.Second
+		return time.Duration(respDir.MaxAge) * time.Second
 	} else if headers.Get("Expires") != "" {
 		_ = "breakpoint"
 		if t, err := time.Parse(time.RFC1123, headers.Get("Expires")); err == nil {
 			//!TODO: use the server time from the Date header to calculate?
-			expiresIn = t.Sub(time.Now())
+			return t.Sub(time.Now())
 		}
 	}
 
-	return true, expiresIn
+	return ifNotAny
 }

--- a/utils/cacheutils/caching_test.go
+++ b/utils/cacheutils/caching_test.go
@@ -1,4 +1,4 @@
-package utils
+package cacheutils
 
 import (
 	"bufio"

--- a/utils/functions.go
+++ b/utils/functions.go
@@ -3,6 +3,7 @@ package utils
 
 import (
 	"os"
+	"time"
 
 	"github.com/ironsmile/nedomi/types"
 )
@@ -16,6 +17,9 @@ func FileExists(filePath string) bool {
 
 // IsMetadataFresh checks whether the supplied metadata could still be used.
 func IsMetadataFresh(obj *types.ObjectMetadata) bool {
-	//!TODO: implementation, tests
-	return true
+	//!TODO: maybe make our own time package in which the time is cached. Calling
+	// time.Now thousands of times per second does not look like a good idea.
+	// This package can be made to work with a precision of one second and never
+	// call time.Now more than that.
+	return time.Unix(obj.ExpiresAt, 0).After(time.Now())
 }

--- a/utils/functions.go
+++ b/utils/functions.go
@@ -2,13 +2,9 @@
 package utils
 
 import (
-	"net/http"
 	"os"
-	"strings"
-	"time"
 
 	"github.com/ironsmile/nedomi/types"
-	"github.com/pquerna/cachecontrol/cacheobject"
 )
 
 // FileExists returns true if filePath is already existing regular file. If it is a
@@ -16,62 +12,6 @@ import (
 func FileExists(filePath string) bool {
 	st, err := os.Stat(filePath)
 	return err == nil && !st.IsDir()
-}
-
-// CacheSatisfiesRequest returs whether the client allows the requested content
-// to be retrieved from the cache and whether the cache we have is fresh enough
-// to be used for handling the request.
-func CacheSatisfiesRequest(obj *types.ObjectMetadata, req *http.Request) bool {
-	//!TODO: improve; implement something like github.com/pquerna/cachecontrol but better
-	//!TODO: write unit tests
-
-	//!TODO: handle cases with respect to https://tools.ietf.org/html/rfc7232
-
-	reqDir, _ := cacheobject.ParseRequestCacheControl(req.Header.Get("Cache-Control"))
-	return !(reqDir.NoCache || reqDir.NoStore)
-}
-
-// IsResponseCacheable returs whether the upstream server allows the requested
-// content to be saved in the cache. True result and 0 duration means that the
-// response has no expiry date.
-func IsResponseCacheable(code int, headers http.Header) (bool, time.Duration) {
-	//!TODO: write a better custom implementation or fork the cacheobject - the API sucks
-	//!TODO: correctly handle cache-control, pragma, etag and vary headers
-	//!TODO: write unit tests
-
-	if code != http.StatusOK && code != http.StatusPartialContent {
-		return false, 0
-	}
-
-	// For now, we do not cache encoded responses
-	if headers.Get("Content-Encoding") != "" {
-		return false, 0
-	}
-
-	// We do not cache multipart range responses
-	if strings.Contains(headers.Get("Content-Type"), "multipart/byteranges") {
-		return false, 0
-	}
-
-	respDir, err := cacheobject.ParseResponseCacheControl(headers.Get("Cache-Control"))
-	if err != nil || respDir.NoCachePresent || respDir.NoStore || respDir.PrivatePresent {
-		return false, 0
-	}
-
-	expiresIn := 1 * time.Hour //!TODO: make configurable
-	if respDir.SMaxAge > 0 {
-		expiresIn = time.Duration(respDir.SMaxAge) * time.Second
-	} else if respDir.MaxAge > 0 {
-		expiresIn = time.Duration(respDir.MaxAge) * time.Second
-	} else if headers.Get("Expires") != "" {
-		_ = "breakpoint"
-		if t, err := time.Parse(time.RFC1123, headers.Get("Expires")); err == nil {
-			//!TODO: use the server time from the Date header to calculate?
-			expiresIn = t.Sub(time.Now())
-		}
-	}
-
-	return true, expiresIn
 }
 
 // IsMetadataFresh checks whether the supplied metadata could still be used.


### PR DESCRIPTION
A new key is introduced `cache_default_duration` in the Location and VirtualHost configs. This is aimed to replace the hardcoded one hour which we have at the moment.

For that end the `utils.IsMetadataFresh` function is implemented and the object's expiration time is added in `types.ObjectMetadata`.