### PR TITLE
Adds a logrotate config for nedomi in the tools

### DIFF
--- a/tools/logrotate.conf
+++ b/tools/logrotate.conf
@@ -1,0 +1,14 @@
+# logrotate config for nedomi
+#
+# typically you would want to add this among the other logrotate configs
+# which may be found in /etc/logrotate.d/ on many distributions.
+#
+# Run `man logrotate` for more information on the syntax.
+
+/cdn/nedomi/logs/*.log {
+    rotate 5
+    size 1G
+    postrotate
+        kill -USR2 `pidof -s nedomi`
+    endscript
+}


### PR DESCRIPTION
The logrotate job upgrades nedomi when it rotates a log file. We should change this to reload signal when it is stable. Or maybe we can add an special signal for recreating the log files.