### PR TITLE
Revert "Add validation for duplicate cache zone+key settings" - fixes #105

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -123,21 +123,6 @@ func TestConfigVerification(t *testing.T) {
 	}
 }
 
-func TestDuplicateCacheSettings(t *testing.T) {
-	t.Parallel()
-	cfg := getNormalConfig()
-
-	if err := ValidateRecursive(cfg); err != nil {
-		t.Errorf("Did not expect an error in the normal config")
-	}
-
-	cfg.HTTP.Servers = append(cfg.HTTP.Servers, cfg.HTTP.Servers[0])
-
-	if err := ValidateRecursive(cfg); err == nil {
-		t.Errorf("Expected an error when having duplicate vhost cache zones and keys")
-	}
-}
-
 func TestHandlersParsing(t *testing.T) {
 	t.Parallel()
 	cfg, err := parseBytes([]byte(`

--- a/config/section_http.go
+++ b/config/section_http.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net"
 )
 
@@ -62,20 +61,6 @@ func (h *HTTP) Validate() error {
 
 	if len(h.Servers) == 0 {
 		return errors.New("There has to be at least one virtual host")
-	}
-
-	// Validate that vhosts do not use the same key for the same cache zone
-	type czPair struct{ zone, key string }
-	usedCzPairs := make(map[czPair]bool)
-	for _, vhost := range h.Servers {
-		if vhost.CacheZone == nil {
-			continue
-		}
-		key := czPair{vhost.CacheZone.ID, vhost.CacheKey}
-		if usedCzPairs[key] {
-			return fmt.Errorf("Virtual host %s has the same cache zone and cache key as another host", vhost.Name)
-		}
-		usedCzPairs[key] = true
 	}
 
 	//!TODO: make sure Listen is valid tcp address


### PR DESCRIPTION
This reverts commit 53123b677263f90a33c3ffb2c1f8ba9e8be10d60.