### PR TITLE
cache.handler: return 500 on 'too many open files'

### DIFF
--- a/handler/cache/bench_test.go
+++ b/handler/cache/bench_test.go
@@ -4,41 +4,28 @@ import (
 	"math/rand"
 	"runtime"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
-func generateFiles(n int) []string {
-	var names = make([]string, n)
+func generateFiles(n int) map[string]string {
+	var files = make(map[string]string, n)
 	for i := 0; n > i; i++ {
-		names[i] = generateMeAString(int64(i), 5)
-		fsmap[names[i]] = generateMeAString(int64(i*n), int64(i*100)%5000+200)
+		name := generateMeAString(int64(i), 5)
+		files[name] = generateMeAString(int64(i*n), rand.Int63n(500)+200)
 	}
-	return names
+	return files
 }
 
 func BenchmarkStorageSimultaneousRangeGetsFillingUp(b *testing.B) {
 	var filesCount = runtime.NumCPU() * 10
-	var files = generateFiles(filesCount)
 
-	up, loc, _, _, cleanup := realerSetup(b)
-	defer cleanup()
-	cacheHandler, err := New(nil, loc, up)
-	if err != nil {
-		b.Fatal(err)
-	}
-	app := &testApp{
-		TB:           b,
-		ctx:          context.Background(),
-		cacheHandler: cacheHandler,
-	}
-
+	app := realerSetup(b)
+	defer app.cleanup()
+	var files = app.getFileSizes()
 	testfunc := func(index int) {
 		file := files[(index)%filesCount]
-		expected := fsmap[file]
-		var begin = rand.Intn(len(expected) - 4)
-		var length = rand.Intn(len(expected)-begin-1) + 2
-		testRange(app, file, uint64(begin), uint64(length))
+		var begin = rand.Intn(file.size - 4)
+		var length = rand.Intn(file.size-begin-1) + 2
+		testRange(app, file.path, uint64(begin), uint64(length))
 	}
 
 	b.ResetTimer()

--- a/handler/cache/handler.go
+++ b/handler/cache/handler.go
@@ -36,6 +36,13 @@ func (h *reqHandler) handle() {
 		h.carbonCopyProxy()
 	} else if err != nil {
 		h.Logger.Errorf("[%p] Storage error when reading metadata: %s", h.req, err)
+		if isTooManyFiles(err) {
+			http.Error(
+				h.resp,
+				http.StatusText(http.StatusInternalServerError),
+				http.StatusInternalServerError)
+			return
+		}
 		if discardErr := h.Cache.Storage.Discard(h.objID); discardErr != nil {
 			h.Logger.Errorf("[%p] Storage error when discarding of object's data: %s", h.req, discardErr)
 		}

--- a/handler/cache/handler_test.go
+++ b/handler/cache/handler_test.go
@@ -1,8 +1,109 @@
 package cache
 
-import "testing"
+import (
+	"io"
+	"net/http"
+	"syscall"
+	"testing"
+
+	"github.com/ironsmile/nedomi/utils/httputils"
+
+	"golang.org/x/net/context"
+)
 
 func TestCachingProxyHandler(t *testing.T) {
 	t.Parallel()
 	t.Skip("TODO: write tests for the handler and all of its helpers")
+}
+
+func TestTooManyFiles(t *testing.T) {
+	// because of the usage of Rlimit - parallel-ing this test
+	// could lead to the failure of others
+
+	var file = "tooManyFiles"
+	fsmap[file] = generateMeAString(1, 50)
+	up, loc, _, _, cleanup := realerSetup(t)
+	defer cleanup()
+	var nofileRlimit = new(syscall.Rlimit)
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, nofileRlimit); err != nil {
+		t.Fatal("Errof on syscall.GetRlimit", err)
+	}
+	defer func(oldlimit syscall.Rlimit) {
+		if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &oldlimit); err != nil {
+			t.Fatal("Errof on syscall.SetRlimit", err)
+		}
+	}(*nofileRlimit)
+	cacheHandler, err := New(nil, loc, up)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := &testApp{
+		TB:           t,
+		ctx:          context.Background(),
+		cacheHandler: cacheHandler,
+	}
+	testFullRequest(app, file) // this should succeed
+
+	nofileRlimit.Cur = 0
+	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, nofileRlimit); err != nil {
+		t.Fatal("Errof on syscall.SetRlimit", err)
+	}
+	req, err := http.NewRequest("GET", "http://example.com/"+file, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testRequest(app, req, http.StatusText(http.StatusInternalServerError)+"\n", http.StatusInternalServerError)
+}
+
+func TestTooManyFilesInTheMiddle(t *testing.T) {
+	// because of the usage of Rlimit - parallel-ing this test
+	// could lead to the failure of others
+
+	var file = "tooManyFiles"
+	fsmap[file] = generateMeAString(1, 50)
+	up, loc, _, _, cleanup := realerSetup(t)
+	defer cleanup()
+	var nofileRlimit = new(syscall.Rlimit)
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, nofileRlimit); err != nil {
+		t.Fatal("Errof on syscall.GetRlimit", err)
+	}
+	defer func(oldlimit syscall.Rlimit) {
+		if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &oldlimit); err != nil {
+			t.Fatal("Errof on syscall.SetRlimit", err)
+		}
+	}(*nofileRlimit)
+	cacheHandler, err := New(nil, loc, up)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := &testApp{
+		TB:           t,
+		ctx:          context.Background(),
+		cacheHandler: cacheHandler,
+	}
+	testFullRequest(app, file) // this should succeed
+
+	req, err := http.NewRequest("GET", "http://example.com/"+file, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, w := io.Pipe()
+	rec := httputils.NewFlexibleResponseWriter(func(frw *httputils.FlexibleResponseWriter) {
+		frw.BodyWriter = w
+	})
+	go app.cacheHandler.RequestHandle(app.ctx, rec, req)
+	var buf [20]byte
+	read(t, r, buf[:2]) // read some
+	// make it fail on next part
+	nofileRlimit.Cur = 0
+	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, nofileRlimit); err != nil {
+		t.Fatal("Errof on syscall.SetRlimit", err)
+	}
+
+	read(t, r, buf[:2]) // read some more
+	n, err := r.Read(buf[:2])
+	if n != 1 {
+		t.Errorf("expected to read 1 not %d", n)
+	}
 }

--- a/handler/cache/handler_test.go
+++ b/handler/cache/handler_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/ironsmile/nedomi/utils/httputils"
-
-	"golang.org/x/net/context"
 )
 
 func TestCachingProxyHandler(t *testing.T) {
@@ -20,10 +18,8 @@ func TestTooManyFiles(t *testing.T) {
 	// because of the usage of Rlimit - parallel-ing this test
 	// could lead to the failure of others
 
-	var file = "tooManyFiles"
-	fsmap[file] = generateMeAString(1, 50)
-	up, loc, _, _, cleanup := realerSetup(t)
-	defer cleanup()
+	app := realerSetup(t)
+	defer app.cleanup()
 	var nofileRlimit = new(syscall.Rlimit)
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, nofileRlimit); err != nil {
 		t.Fatal("Errof on syscall.GetRlimit", err)
@@ -33,15 +29,8 @@ func TestTooManyFiles(t *testing.T) {
 			t.Fatal("Errof on syscall.SetRlimit", err)
 		}
 	}(*nofileRlimit)
-	cacheHandler, err := New(nil, loc, up)
-	if err != nil {
-		t.Fatal(err)
-	}
-	app := &testApp{
-		TB:           t,
-		ctx:          context.Background(),
-		cacheHandler: cacheHandler,
-	}
+	var file = app.getFileName()
+
 	testFullRequest(app, file) // this should succeed
 
 	nofileRlimit.Cur = 0
@@ -59,10 +48,8 @@ func TestTooManyFilesInTheMiddle(t *testing.T) {
 	// because of the usage of Rlimit - parallel-ing this test
 	// could lead to the failure of others
 
-	var file = "tooManyFiles"
-	fsmap[file] = generateMeAString(1, 50)
-	up, loc, _, _, cleanup := realerSetup(t)
-	defer cleanup()
+	app := realerSetup(t)
+	defer app.cleanup()
 	var nofileRlimit = new(syscall.Rlimit)
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, nofileRlimit); err != nil {
 		t.Fatal("Errof on syscall.GetRlimit", err)
@@ -72,15 +59,8 @@ func TestTooManyFilesInTheMiddle(t *testing.T) {
 			t.Fatal("Errof on syscall.SetRlimit", err)
 		}
 	}(*nofileRlimit)
-	cacheHandler, err := New(nil, loc, up)
-	if err != nil {
-		t.Fatal(err)
-	}
-	app := &testApp{
-		TB:           t,
-		ctx:          context.Background(),
-		cacheHandler: cacheHandler,
-	}
+	var file = app.getFileName()
+
 	testFullRequest(app, file) // this should succeed
 
 	req, err := http.NewRequest("GET", "http://example.com/"+file, nil)
@@ -93,7 +73,7 @@ func TestTooManyFilesInTheMiddle(t *testing.T) {
 		frw.BodyWriter = w
 	})
 	go app.cacheHandler.RequestHandle(app.ctx, rec, req)
-	var buf [20]byte
+	var buf [32]byte
 	read(t, r, buf[:2]) // read some
 	// make it fail on next part
 	nofileRlimit.Cur = 0
@@ -102,7 +82,7 @@ func TestTooManyFilesInTheMiddle(t *testing.T) {
 	}
 
 	read(t, r, buf[:2]) // read some more
-	n, err := r.Read(buf[:2])
+	n, _ := r.Read(buf[:32])
 	if n != 1 {
 		t.Errorf("expected to read 1 not %d", n)
 	}

--- a/handler/cache/old_test.go
+++ b/handler/cache/old_test.go
@@ -2,11 +2,9 @@ package cache
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
-	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -14,11 +12,7 @@ import (
 
 	"github.com/ironsmile/nedomi/config"
 	"github.com/ironsmile/nedomi/logger"
-	"github.com/ironsmile/nedomi/mock"
-	"github.com/ironsmile/nedomi/storage"
 	"github.com/ironsmile/nedomi/types"
-	"github.com/ironsmile/nedomi/utils/httputils"
-	"github.com/ironsmile/nedomi/utils/testutils"
 
 	"golang.org/x/net/context"
 
@@ -30,12 +24,7 @@ func init() {
 	rand.Seed(time.Now().Unix())
 }
 
-var fsmap = map[string]string{
-	"test.flv": "This is FLV test data. As there is noting that requires the data to be actual valid flv a strings is fine.",
-	"path":     "awesome test path content of the test material more letters/bytes to be tested with",
-}
-
-func fsMapHandler() http.HandlerFunc {
+func fsMapHandler(fsmap map[string]string) http.HandlerFunc {
 	return func(wr http.ResponseWriter, req *http.Request) {
 		wr.Header().Add("Expires", time.Now().Add(time.Hour).Format(time.RFC1123))
 		http.FileServer(httpfs.New(mapfs.New(fsmap))).ServeHTTP(wr, req)
@@ -50,45 +39,6 @@ func newStdLogger() types.Logger {
 	return l
 }
 
-func setup(t *testing.T) (*mock.RequestHandler, *types.Location, config.CacheZone, int, func()) {
-	cpus := runtime.NumCPU()
-	goroutines := cpus * 4
-	runtime.GOMAXPROCS(cpus * 20)
-	up := mock.NewRequestHandler(fsMapHandler())
-	loc := &types.Location{}
-	var err error
-	loc.Logger = newStdLogger()
-
-	path, cleanup := testutils.GetTestFolder(t)
-
-	cz := config.CacheZone{
-		ID:             "1",
-		Type:           "disk",
-		Path:           path,
-		StorageObjects: 200000,
-		PartSize:       5,
-	}
-
-	ca := mock.NewCacheAlgorithm(&mock.CacheAlgorithmRepliers{
-		Lookup:     func(*types.ObjectIndex) bool { return true },
-		ShouldKeep: func(*types.ObjectIndex) bool { return true },
-	})
-	st, err := storage.New(&cz, loc.Logger)
-	if err != nil {
-		panic(err)
-	}
-	loc.CacheKey = "test"
-	loc.Cache = &types.CacheZone{
-		ID:        cz.ID,
-		PartSize:  cz.PartSize,
-		Algorithm: ca,
-		Scheduler: storage.NewScheduler(),
-		Storage:   st,
-	}
-
-	return up, loc, cz, goroutines, cleanup
-}
-
 // Tests the storage headers map in multithreading usage. An error will be
 // triggered by a race condition. This may or may not happen. So no failures
 // in the test do not mean there are no problems. But it may catch an error
@@ -99,8 +49,8 @@ func setup(t *testing.T) (*mock.RequestHandler, *types.Location, config.CacheZon
 // the test fails with a panic.
 func TestStorageHeadersFunctionWithManyGoroutines(t *testing.T) {
 	t.Parallel()
-	up, loc, _, goroutines, cleanup := setup(t)
-	defer cleanup()
+	app := realerSetup(t)
+	defer app.cleanup()
 
 	headerKeyFunc := func(i int) string {
 		return fmt.Sprintf("X-Header-%d", i)
@@ -109,23 +59,18 @@ func TestStorageHeadersFunctionWithManyGoroutines(t *testing.T) {
 	headerValueFunc := func(i int) string {
 		return fmt.Sprintf("value-%d", i)
 	}
+	var pathFile = generateMeAString(20, 30)
 
 	// setup the response
 	for i := 0; i < 100; i++ {
 		handler := func(num int) func(w http.ResponseWriter, r *http.Request) {
 			return func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Add(headerKeyFunc(num), headerValueFunc(num))
-				w.WriteHeader(200)
-				fmt.Fprintf(w, fsmap["path"])
+				fmt.Fprintf(w, pathFile)
 			}
 		}(i)
 
-		up.Handle("/path/"+strconv.Itoa(i), http.HandlerFunc(handler))
-	}
-
-	cacheHandler, err := New(nil, loc, up)
-	if err != nil {
-		t.Fatal(err)
+		app.up.Handle("/path/"+strconv.Itoa(i), http.HandlerFunc(handler))
 	}
 
 	testFunc := func(t *testing.T, i, j int) {
@@ -134,84 +79,40 @@ func TestStorageHeadersFunctionWithManyGoroutines(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		cacheHandler.RequestHandle(context.Background(), rec, req)
+		app.cacheHandler.RequestHandle(context.Background(), rec, req)
 		val := rec.Header().Get(headerKeyFunc(i))
 		expVal := headerValueFunc(i)
 		if val != expVal {
 			t.Errorf("Expected header value %s and received %s", expVal, val)
 		}
 	}
-	concurrentTestHelper(t, goroutines, 100, testFunc)
+	concurrentTestHelper(t, 20, 100, testFunc)
 }
 
 func TestStorageSimultaneousGets(t *testing.T) {
 	t.Parallel()
-	expected := fsmap["path"]
-	up, loc, _, goroutines, cleanup := setup(t)
-	defer cleanup()
-	runtime.GOMAXPROCS(runtime.NumCPU())
-	cacheHandler, err := New(nil, loc, up)
-	if err != nil {
-		t.Fatal(err)
-	}
-	concurrentTestHelper(t, goroutines, 100, func(t *testing.T, i, j int) {
-		rec := httptest.NewRecorder()
-		req, err := http.NewRequest("GET", "http://example.com/path", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		cacheHandler.RequestHandle(context.Background(), rec, req)
-		if rec.Code != http.StatusOK {
-			t.Errorf("Got code different from OK %d", rec.Code)
-		}
-		b, err := ioutil.ReadAll(rec.Body)
-		if err != nil {
-			t.Errorf("Got error while reading response on %d, %d: %s", j, i, err)
-		}
-		if string(b) != expected {
-			t.Errorf("The response was expected to be \n'%s'\n but it was \n'%s'", expected, string(b))
-		}
+	app := realerSetup(t)
+	defer app.cleanup()
+	var files = app.getFileSizes()
+	files = files[:len(files)/2] // it takes too long otherwise
+	concurrentTestHelper(t, len(files)*5, 50, func(t *testing.T, i, j int) {
+		testFullRequest(app, files[(i*j)%len(files)].path)
 	})
 }
 
 func TestStorageSimultaneousRangeGets(t *testing.T) {
 	t.Parallel()
-	var expected = fsmap["path"]
-	up, loc, _, goroutines, cleanup := setup(t)
-	defer cleanup()
-	runtime.GOMAXPROCS(runtime.NumCPU())
-	cacheHandler, err := New(nil, loc, up)
-	if err != nil {
-		t.Fatal(err)
-	}
+	app := realerSetup(t)
+	defer app.cleanup()
+	var files = app.getFileSizes()
 	testfunc := func(t *testing.T, i, j int) {
-		var begin = rand.Intn(len(expected) - 4)
-		var length = rand.Intn(len(expected)-begin-1) + 2
-		var rec = httptest.NewRecorder()
-		ran := httputils.Range{
-			Start:  uint64(begin),
-			Length: uint64(length),
-		}
-		req, err := http.NewRequest("GET", "http://example.com/path", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		req.Header.Add("Range", ran.Range())
-		cacheHandler.RequestHandle(context.Background(), rec, req)
-		if rec.Code != http.StatusPartialContent {
-			t.Errorf("Got code different from OK %d", rec.Code)
-		}
-		b, err := ioutil.ReadAll(rec.Body)
-		if err != nil {
-			t.Errorf("Got error while reading response on %d, %d: %s", j, i, err)
-		}
-		expected := expected[begin : begin+length]
-		if string(b) != expected {
-			t.Errorf("The response for `%+v`was expected to be \n'%s'\n but it was \n'%s'", req, expected, string(b))
-		}
+		var file = files[(i*j)%len(files)]
+		var begin = rand.Intn(file.size - 4)
+		var length = rand.Intn(file.size-begin-1) + 2
+		testRange(app, file.path, uint64(begin), uint64(length))
 	}
 
-	concurrentTestHelper(t, goroutines, 100, testfunc)
+	concurrentTestHelper(t, len(files)*5, 50, testfunc)
 }
 
 func concurrentTestHelper(t *testing.T, goroutines, iterations int, test func(t *testing.T, i, j int)) {

--- a/handler/cache/specifics_test.go
+++ b/handler/cache/specifics_test.go
@@ -74,6 +74,7 @@ func testFullRequest(t *testApp, path string) {
 func TestVeryFragmentedFile(t *testing.T) {
 	var file = "fragmented"
 	fsmap[file] = generateMeAString(1, 1024)
+	t.Parallel()
 	up, loc, _, _, cleanup := realerSetup(t)
 	defer cleanup()
 	cacheHandler, err := New(nil, loc, up)
@@ -174,6 +175,7 @@ func readerFromSource(s rand.Source) io.Reader {
 func Test2PartsFile(t *testing.T) {
 	var file = "2parts"
 	fsmap[file] = generateMeAString(2, 10)
+	t.Parallel()
 	up, loc, _, _, cleanup := realerSetup(t)
 	defer cleanup()
 	cacheHandler, err := New(nil, loc, up)

--- a/handler/cache/specifics_test.go
+++ b/handler/cache/specifics_test.go
@@ -23,8 +23,31 @@ import (
 
 type testApp struct {
 	testing.TB
+	up           *mock.RequestHandler
 	cacheHandler *CachingProxy
 	ctx          context.Context
+	fsmap        map[string]string
+	cleanup      func()
+}
+
+func (a *testApp) getFileName() string {
+	return a.getFileSizes()[0].path // lazy
+}
+
+type fileInfo struct {
+	path string
+	size int
+}
+
+func (a *testApp) getFileSizes() []fileInfo {
+	var files = make([]fileInfo, 0, len(a.fsmap))
+	for key, value := range a.fsmap {
+		files = append(files, fileInfo{
+			path: key,
+			size: len(value),
+		})
+	}
+	return files
 }
 
 func reqForRange(path string, begin, length uint64) *http.Request {
@@ -56,13 +79,13 @@ func testRequest(t *testApp, req *http.Request, expected string, code int) {
 }
 
 func testRange(t *testApp, path string, begin, length uint64) {
-	expected := fsmap[path]
+	expected := t.fsmap[path]
 	req := reqForRange(path, begin, length)
 	testRequest(t, req, expected[begin:begin+length], http.StatusPartialContent)
 }
 
 func testFullRequest(t *testApp, path string) {
-	expected := fsmap[path]
+	expected := t.fsmap[path]
 	req, err := http.NewRequest("GET", "http://example.com/"+path, nil)
 	if err != nil {
 		panic(err)
@@ -72,20 +95,12 @@ func testFullRequest(t *testApp, path string) {
 }
 
 func TestVeryFragmentedFile(t *testing.T) {
-	var file = "fragmented"
-	fsmap[file] = generateMeAString(1, 1024)
 	t.Parallel()
-	up, loc, _, _, cleanup := realerSetup(t)
-	defer cleanup()
-	cacheHandler, err := New(nil, loc, up)
-	if err != nil {
-		t.Fatal(err)
-	}
-	app := &testApp{
-		TB:           t,
-		ctx:          context.Background(),
-		cacheHandler: cacheHandler,
-	}
+	app := realerSetup(t)
+	var file = "long"
+	app.fsmap[file] = generateMeAString(1, 2000)
+	defer app.cleanup()
+
 	testRange(app, file, 5, 10)
 	testRange(app, file, 5, 2)
 	testRange(app, file, 2, 2)
@@ -101,11 +116,10 @@ func TestVeryFragmentedFile(t *testing.T) {
 	testRange(app, file, 3, 1000)
 }
 
-func realerSetup(t testing.TB) (*mock.RequestHandler, *types.Location, *config.CacheZone, int, func()) {
+func realerSetupFromMap(t testing.TB, fsmap map[string]string) *testApp {
+	up := mock.NewRequestHandler(fsMapHandler(fsmap))
 	cpus := runtime.NumCPU()
-	goroutines := cpus * 4
 	runtime.GOMAXPROCS(cpus)
-	up := mock.NewRequestHandler(fsMapHandler())
 	loc := &types.Location{}
 	var err error
 	loc.Logger = newStdLogger()
@@ -118,7 +132,7 @@ func realerSetup(t testing.TB) (*mock.RequestHandler, *types.Location, *config.C
 		ID:             "1",
 		Type:           "disk",
 		Path:           path,
-		StorageObjects: 20,
+		StorageObjects: 200,
 		Algorithm:      "lru",
 		PartSize:       5,
 	}
@@ -139,7 +153,23 @@ func realerSetup(t testing.TB) (*mock.RequestHandler, *types.Location, *config.C
 		Storage:   st,
 	}
 
-	return up, loc, cz, goroutines, cleanup
+	cacheHandler, err := New(nil, loc, up)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := &testApp{
+		TB:           t,
+		up:           up,
+		ctx:          context.Background(),
+		cacheHandler: cacheHandler,
+		fsmap:        fsmap,
+		cleanup:      cleanup,
+	}
+	return app
+}
+
+func realerSetup(t testing.TB) *testApp {
+	return realerSetupFromMap(t, generateFiles(10))
 }
 
 // generates a pseudo-randomized string to be used as the contents of a file
@@ -173,20 +203,12 @@ func readerFromSource(s rand.Source) io.Reader {
 }
 
 func Test2PartsFile(t *testing.T) {
+	var fsmap = make(map[string]string)
 	var file = "2parts"
 	fsmap[file] = generateMeAString(2, 10)
 	t.Parallel()
-	up, loc, _, _, cleanup := realerSetup(t)
-	defer cleanup()
-	cacheHandler, err := New(nil, loc, up)
-	if err != nil {
-		t.Fatal(err)
-	}
-	app := &testApp{
-		TB:           t,
-		ctx:          context.Background(),
-		cacheHandler: cacheHandler,
-	}
+	app := realerSetupFromMap(t, fsmap)
+	defer app.cleanup()
 	testRange(app, file, 2, 8)
 	testFullRequest(app, file)
 }


### PR DESCRIPTION
Up until now on 'too many open files' a new connection to the upstream
was opened which probably would fail as well.

This change does not try to make it less likely for 'too many open files'
to occur, but instead cuts short the request handling and returns an
InternalServerError where possible or just stop returning data if
already in the middle of a response.