### PR TITLE
handler.headers: don't rewrite response header before next

### DIFF
--- a/handler/headers/README.md
+++ b/handler/headers/README.md
@@ -2,7 +2,7 @@
 
 This handler enables changing both the response or request headers before calling the next handler.
 
-The request headers are rewritten when it is the handler's turn in the handler chain. Rewriting the response headers is done at the handle's turn *and once more* before they are send to the client. This is to ensure that they have not been overwritten by the next handler. The rewriting of the response Headers before continuing is to enable the handlers in chain after `headers` to use the rewritten response headers - probably not a good practice, but it might be desirable.
+The request headers are rewritten when it's the handler's turn in the handler chain. Rewriting the response headers is done before they are send to the client. This is to ensure that they have not been overwritten by the next handler.
 
 All the headers keys will be canonized before processing. The settings should have "response" and "request" keys with values the same as config.HeadersRewrite (see the example below). If one is missing no action will be taken for the corresponding headers.
 

--- a/handler/headers/headers.go
+++ b/handler/headers/headers.go
@@ -34,7 +34,6 @@ func (h *Headers) RequestHandle(ctx context.Context, w http.ResponseWriter, r *h
 		h.request.rewrite(r.Header)
 	}
 	if !h.response.isEmpty() {
-		h.response.rewrite(w.Header())
 		w = h.wrapResponseWriter(w)
 	}
 	h.next.RequestHandle(ctx, w, r)


### PR DESCRIPTION
this had the small problem that added headers will be added twice. Given
the lack of evidince that the feature was needed and the impossibility
of implementing it well it is now removed.