### PR TITLE
fix import of 'testing' in production code

### DIFF
--- a/app/init_test.go
+++ b/app/init_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ironsmile/nedomi/config"
 	"github.com/ironsmile/nedomi/types"
+	"github.com/ironsmile/nedomi/utils"
 	"github.com/ironsmile/nedomi/utils/testutils"
 )
 
@@ -17,7 +18,7 @@ func TestConcurrentCacheReload(t *testing.T) {
 func TestAliasesMatchingAfterInit(t *testing.T) {
 	t.Parallel()
 
-	path, err := testutils.ProjectPath()
+	path, err := utils.ProjectPath()
 	if err != nil {
 		t.Fatalf("Was not able to find the project dir: %s", err)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ironsmile/nedomi/utils/testutils"
+	"github.com/ironsmile/nedomi/utils"
 )
 
 //!TODO: split this in multiple files and write additional tests
 
 func TestExampleConfig(t *testing.T) {
 	t.Parallel()
-	path, err := testutils.ProjectPath()
+	path, err := utils.ProjectPath()
 
 	if err != nil {
 		t.Fatalf("Was not able to find project path: %s", err)

--- a/handler/status/status_page.go
+++ b/handler/status/status_page.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ironsmile/nedomi/config"
 	"github.com/ironsmile/nedomi/contexts"
 	"github.com/ironsmile/nedomi/types"
-	"github.com/ironsmile/nedomi/utils/testutils"
+	"github.com/ironsmile/nedomi/utils"
 )
 
 // ServerStatusHandler is a simple handler that handles the server status page.
@@ -146,7 +146,7 @@ func New(cfg *config.Handler, l *types.Location, next types.RequestHandler) (*Se
 	if st, err := os.Stat(s.Path); (err != nil && err.(*os.PathError) != nil &&
 		!strings.HasPrefix(s.Path, "/")) || (err == nil && !st.IsDir()) {
 
-		projPath, err := testutils.ProjectPath()
+		projPath, err := utils.ProjectPath()
 		if err == nil {
 			fullPath := path.Join(projPath, s.Path)
 			if st, err := os.Stat(fullPath); err == nil && st.IsDir() {

--- a/utils/functions.go
+++ b/utils/functions.go
@@ -2,7 +2,10 @@
 package utils
 
 import (
+	"errors"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/ironsmile/nedomi/types"
@@ -22,4 +25,23 @@ func IsMetadataFresh(obj *types.ObjectMetadata) bool {
 	// This package can be made to work with a precision of one second and never
 	// call time.Now more than that.
 	return time.Unix(obj.ExpiresAt, 0).After(time.Now())
+}
+
+// ProjectPath returns a path to the project source as an absolute directory name.
+func ProjectPath() (string, error) {
+	gopath := os.ExpandEnv("$GOPATH")
+	relPath := filepath.FromSlash("src/github.com/ironsmile/nedomi")
+	for _, path := range strings.Split(gopath, ":") {
+		rootPath := filepath.Join(path, relPath)
+		entry, err := os.Stat(rootPath)
+		if err != nil {
+			continue
+		}
+
+		if entry.IsDir() {
+			return rootPath, nil
+		}
+	}
+
+	return "", errors.New("Was not able to find the project path")
 }

--- a/utils/testutils/test_helpers.go
+++ b/utils/testutils/test_helpers.go
@@ -1,11 +1,8 @@
 package testutils
 
 import (
-	"errors"
 	"io/ioutil"
 	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 )
@@ -38,23 +35,4 @@ func ShouldntFail(t testing.TB, errors ...error) {
 			t.Fatalf("An unexpected error occured in statement %d: %s", idx+1, err)
 		}
 	}
-}
-
-// ProjectPath returns a path to the project source as an absolute directory name.
-func ProjectPath() (string, error) {
-	gopath := os.ExpandEnv("$GOPATH")
-	relPath := filepath.FromSlash("src/github.com/ironsmile/nedomi")
-	for _, path := range strings.Split(gopath, ":") {
-		rootPath := filepath.Join(path, relPath)
-		entry, err := os.Stat(rootPath)
-		if err != nil {
-			continue
-		}
-
-		if entry.IsDir() {
-			return rootPath, nil
-		}
-	}
-
-	return "", errors.New("Was not able to find the project path")
 }


### PR DESCRIPTION
this was due to importing ./utils/testutils package in production code in order
to use ProjectPath, which is why it was moved in ./utils