### PR TITLE
add NotNilNextHandler error type and use it in handler.proxy

### DIFF
--- a/handler/proxy/new.go
+++ b/handler/proxy/new.go
@@ -17,6 +17,10 @@ type Settings struct {
 
 // New returns a configured and ready to use Upstream instance.
 func New(cfg *config.Handler, l *types.Location, next types.RequestHandler) (*ReverseProxy, error) {
+	if next != nil {
+		return nil, types.NotNilNextHandler(cfg.Type)
+	}
+
 	if l.Upstream == nil {
 		return nil, fmt.Errorf("No upstream set for proxy handler in %s", l.Name)
 	}

--- a/types/request_handler.go
+++ b/types/request_handler.go
@@ -31,3 +31,10 @@ type NilNextHandler string
 func (n NilNextHandler) Error() string {
 	return fmt.Sprintf("%s: next handler is required but it's nil", n)
 }
+
+// NotNilNextHandler is an error type to be returned when a next handler is not nil but it should be
+type NotNilNextHandler string
+
+func (n NotNilNextHandler) Error() string {
+	return fmt.Sprintf("%s: next handler is not nil but it should be", n)
+}


### PR DESCRIPTION
for handlers who do not call next (ever) it's unreasonable to have next
handler - it's most probably configuration error which may or may not be
fatal. For this reasons it should be prohibited.