### PR TITLE
handler.cache: rewrite some time/date headers - fixes #119

### DIFF
--- a/handler/cache/handler_helpers.go
+++ b/handler/cache/handler_helpers.go
@@ -18,8 +18,7 @@ import (
 // Hop-by-hop headers. These are removed when sent to the client.
 var hopHeaders = httputils.GetHopByHopHeaders()
 
-//!TODO: add Date and cache-expity headers here? we probably have to manage them on our own
-var metadataHeadersToFilter = append(hopHeaders, "Content-Length", "Content-Range")
+var metadataHeadersToFilter = append(hopHeaders, "Content-Length", "Content-Range", "Date", "Expires", "Age", "Cache-Control")
 
 // Returns a new HTTP 1.1 request that has no body. It also clears headers like
 // accept-encoding and rearranges the requested ranges so they match part


### PR DESCRIPTION
the rewritten headers when serving from the cache:
Date, Age, Cache-Control (with max-age), Expires

Now non of this would be cached as well as they are always recalculated.