### PR TITLE
change http.Server.*Timeout to be on a per Read|Write basis

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -14,10 +14,11 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/facebookgo/grace/gracehttp"
+	"github.com/MStoykov/grace/gracehttp"
 
 	"github.com/ironsmile/nedomi/config"
 	"github.com/ironsmile/nedomi/types"
+	"github.com/ironsmile/nedomi/utils/netutils"
 )
 
 // Application is the type which represents the webserver. It is responsible for
@@ -124,7 +125,7 @@ func (a *Application) listenAndServe() error {
 	// Serve accepts incoming connections on the Listener lsn, creating a
 	// new service goroutine for each.  The service goroutines read requests and
 	// then call the handler (i.e. ServeHTTP() ) to reply to them.
-	return gracehttp.Serve(a.httpSrv)
+	return gracehttp.ServeWithWrapper(netutils.DeadlineToTimeoutListener, a.httpSrv)
 }
 
 // Stop makes sure the application is completely stopped and all of its

--- a/utils/netutils/timeout_conn.go
+++ b/utils/netutils/timeout_conn.go
@@ -1,0 +1,53 @@
+package netutils
+
+import (
+	"net"
+	"time"
+)
+
+// timeoutConn is a connection for which Deadline sets a timeout equal to
+// the difference to which the deadline was set. That timeout is then use to
+// Timeout each read|write on the connection
+type timeoutConn struct {
+	net.Conn
+	readTimeout, writeTimeout time.Duration
+}
+
+// newTimeoutConn returns a timeout conn wrapping around the provided one
+func newTimeoutConn(conn net.Conn) *timeoutConn {
+	return &timeoutConn{Conn: conn}
+}
+
+func (tc *timeoutConn) Read(data []byte) (int, error) {
+	tc.Conn.SetReadDeadline(time.Now().Add(tc.readTimeout))
+	return tc.Conn.Read(data)
+}
+
+func (tc *timeoutConn) Write(data []byte) (int, error) {
+	tc.Conn.SetWriteDeadline(time.Now().Add(tc.writeTimeout))
+	return tc.Conn.Write(data)
+}
+
+// SetDeadline sets both the read and write timeouts to the difference
+// from now to the time provied and calls the underlying SetDeadline
+func (tc *timeoutConn) SetDeadline(t time.Time) error {
+	tc.readTimeout = t.Sub(time.Now())
+	tc.writeTimeout = tc.readTimeout
+	return tc.Conn.SetDeadline(t)
+}
+
+// SetReadDeadline sets the read timeout to the difference from now
+// and the time provided as well as calls the underlying SetReadDeadline
+// and returns what it returns
+func (tc *timeoutConn) SetReadDeadline(t time.Time) error {
+	tc.readTimeout = t.Sub(time.Now())
+	return tc.Conn.SetReadDeadline(t)
+}
+
+// SetWriteDeadline sets the write timeout to the difference from now
+// and the time provided as well as calls the underlying SetWriteDeadline
+// and returns what it returns
+func (tc *timeoutConn) SetWriteDeadline(t time.Time) error {
+	tc.writeTimeout = t.Sub(time.Now())
+	return tc.Conn.SetWriteDeadline(t)
+}

--- a/utils/netutils/timeout_listener.go
+++ b/utils/netutils/timeout_listener.go
@@ -1,0 +1,28 @@
+package netutils
+
+import "net"
+
+type timeoutConnListener struct {
+	net.Listener
+}
+
+// DeadlineToTimeoutListener wraps the provided listener in a new one
+// whose Accept methods returns a wrapped net.Conn whose Deadlines set
+// timeouts for each Read|Write individually.
+// Example: a conn.SetReadDeadline(time.Now().Add(time.Second)) will set a timeout
+// of one second. With the standard conn|listener this will mean that if you start reading a response
+// calling Read multiple times but it all takes more than a second it will timeout. With a connection
+// from this listener if each call to Read finishes in less than a second the connection will not timeout.
+func DeadlineToTimeoutListener(l net.Listener) net.Listener {
+	return &timeoutConnListener{Listener: l}
+}
+
+// Accept calls the underlying accept and wraps the connection if not nil in timeouting connection
+func (t *timeoutConnListener) Accept() (net.Conn, error) {
+	conn, err := t.Listener.Accept()
+	if conn != nil {
+		conn = newTimeoutConn(conn)
+	}
+
+	return conn, err
+}


### PR DESCRIPTION
This is fun feature which circumvents the fact that http.Server timeout
is not useful when you have long living connections. If you have a
connection which will have to live for 20 minutes you can either put
your timeout to something above 20 minutes and possibly have connections
which are stale for 20 minutes, have timeout connections for no good
reason or do what is done through this commit.

This commit changes the meaning of net.Conn.Set*Deadline to mean
"calculate me a timeout from now till the deadline and than use that to
deadline each Read|Write operation for that timeout", not all of them.

This means that you can have a timeout of 10 seconds and connections
which have been used to transmit data for as long as each Read|Write
takes less than 10 seconds.

This is only done for the connections served by facebook's grace - the
incoming traffic for nedomi. For this reason the grace project was ...
forked. Vendoring the gracehttp package should be considered at a future
date.