### PR TITLE
make it possible for sendfile to be used

### DIFF
--- a/app/write_log.go
+++ b/app/write_log.go
@@ -163,3 +163,7 @@ func (l *responseLogger) Status() int {
 func (l *responseLogger) Size() int {
 	return l.size
 }
+
+func (l *responseLogger) ReadFrom(r io.Reader) (n int64, err error) {
+	return io.Copy(l.ResponseWriter, r)
+}

--- a/handler/cache/caching_proxy.go
+++ b/handler/cache/caching_proxy.go
@@ -2,14 +2,12 @@ package cache
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 
 	"golang.org/x/net/context"
 
 	"github.com/ironsmile/nedomi/config"
 	"github.com/ironsmile/nedomi/types"
-	"github.com/ironsmile/nedomi/utils"
 )
 
 // CachingProxy is resposible for caching the metadata and parts the requested
@@ -40,25 +38,7 @@ func (c *CachingProxy) RequestHandle(ctx context.Context, resp http.ResponseWrit
 		return
 	}
 
-	rh := &reqHandler{c, ctx, req, toResponseWriteCloser(resp), c.NewObjectIDForURL(req.URL), nil}
+	rh := &reqHandler{c, ctx, req, resp, c.NewObjectIDForURL(req.URL), nil}
 	rh.handle()
 	c.Logger.Logf("[%p] Done!", req)
-}
-
-func toResponseWriteCloser(rw http.ResponseWriter) responseWriteCloser {
-	if rwc, ok := rw.(responseWriteCloser); ok {
-		return rwc
-	}
-	return struct {
-		http.ResponseWriter
-		io.Closer
-	}{
-		rw,
-		utils.NopCloser(nil),
-	}
-}
-
-type responseWriteCloser interface {
-	http.ResponseWriter
-	io.Closer
 }

--- a/handler/cache/handler.go
+++ b/handler/cache/handler.go
@@ -20,7 +20,7 @@ type reqHandler struct {
 	*CachingProxy
 	ctx   context.Context
 	req   *http.Request
-	resp  responseWriteCloser
+	resp  http.ResponseWriter
 	objID *types.ObjectID
 	obj   *types.ObjectMetadata
 }

--- a/handler/cache/part_writer.go
+++ b/handler/cache/part_writer.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/ironsmile/nedomi/types"
+	"github.com/ironsmile/nedomi/utils"
 	"github.com/ironsmile/nedomi/utils/httputils"
 )
 
@@ -103,10 +104,10 @@ func (pw *partWriter) flushBuffer() error {
 
 func (pw *partWriter) Close() error {
 	if pw.currentPos-pw.startPos != pw.length {
-		return &partWriterShortWrite{
+		return utils.WrapErrorWithStack(&partWriterShortWrite{
 			expected: pw.length,
 			actual:   pw.currentPos - pw.startPos,
-		}
+		})
 	}
 	if pw.buf == nil {
 		return nil

--- a/utils/httputils/flexible_response_writer.go
+++ b/utils/httputils/flexible_response_writer.go
@@ -66,4 +66,16 @@ func (frw *FlexibleResponseWriter) Close() error {
 	return frw.BodyWriter.Close()
 }
 
+// ReadFrom uses io.Copy with the BoduWriter if available after writing headers and checking that the writer is set
+func (frw *FlexibleResponseWriter) ReadFrom(r io.Reader) (n int64, err error) {
+	if !frw.wroteHeader {
+		frw.WriteHeader(frw.Code)
+	}
+
+	if frw.BodyWriter == nil {
+		return 0, utils.NewErrorWithStack("The body is not initialized, writes are not accepted.")
+	}
+	return io.Copy(frw.BodyWriter, r)
+}
+
 //!TODO: implement http.CloseNotifier

--- a/utils/netutils/timeout_conn.go
+++ b/utils/netutils/timeout_conn.go
@@ -93,7 +93,7 @@ func (tc *timeoutConn) ReadFrom(r io.Reader) (n int64, err error) {
 		}
 		if readErr != nil {
 			pool.Put(bufp)
-			if err == io.EOF {
+			if readErr == io.EOF {
 				return n, nil
 			}
 			return

--- a/utils/readers_test.go
+++ b/utils/readers_test.go
@@ -77,7 +77,10 @@ func TestLimitedReadCloser(t *testing.T) {
 func TestSkipReaderClose(t *testing.T) {
 	t.Parallel()
 	hw := ioutil.NopCloser(bytes.NewBufferString("Hello, World!"))
-	src := SkipReadCloser(hw, 5)
+	src, err := SkipReadCloser(hw, 5)
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
 	defer func() {
 		testutils.ShouldntFail(t, src.Close())
 	}()
@@ -96,7 +99,10 @@ func TestSkipReaderCloseWithPipe(t *testing.T) {
 	var input = []byte{'a', 'b', 'c', 'd'}
 	var output = []byte{'b', 'c', 'd'}
 	r, w := io.Pipe()
-	src := SkipReadCloser(r, 1)
+	src, err := SkipReadCloser(r, 1)
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
 	go func() {
 		if _, err := w.Write(input); err != nil {
 			t.Fatalf("Unexpected Write error: %s", err)

--- a/utils/writers.go
+++ b/utils/writers.go
@@ -14,6 +14,16 @@ func NopCloser(w io.Writer) io.WriteCloser {
 	return nopCloser{w}
 }
 
+// AddCloser adds io.Closer to a io.Writer.
+// If the provided io.Writer is io.WriteCloser
+// it's just casted, otherwise a NopCloser is used
+func AddCloser(w io.Writer) io.WriteCloser {
+	if wc, ok := w.(io.WriteCloser); ok {
+		return wc
+	}
+	return NopCloser(w)
+}
+
 type multiWriteCloser struct {
 	writers []io.WriteCloser
 }


### PR DESCRIPTION
there a lot of changes to many of the io.Writer/io.Reader
implementations. All of them are more or less so that an io.Copy with a
io.Reader being *os.File and an io.Writer of net.Conn could be called at
some point.

Currently this is not possible with the throttle handler - which will
be implemented at a later time.

The same is true for the mp4 handler when a start parameter is provided.
This will be harder to fix and will need another change to the
github.com/MStoykov/mp4 library.

The flv handler was not tested.

The usage of sendfile ofcourse does not work if used on operating system
with no sendfile syscall or an alternative. Also it's only possible to
be done with os.File, so only disk cached or static content can be sent.