### PR TITLE
handler proxy: implement #168

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -199,3 +199,8 @@ func (a *Application) Version() types.AppVersion {
 func (a *Application) Started() time.Time {
 	return a.started
 }
+
+// GetUpstream gets a configured upstream by it's id
+func (a *Application) GetUpstream(id string) types.Upstream {
+	return a.upstreams[id]
+}

--- a/handler/proxy/new.go
+++ b/handler/proxy/new.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/ironsmile/nedomi/config"
 	"github.com/ironsmile/nedomi/types"
@@ -10,10 +11,11 @@ import (
 
 // Settings contains the possible settings for the proxy
 type Settings struct {
-	UserAgent              string `json:"user_agent"`
-	HostHeader             string `json:"host_header"`
-	HostHeaderKeepOriginal bool   `json:"host_header_keep_original"`
-	UpstreamHashPrefix     string `json:"upstream_hash_prefix"`
+	UserAgent              string            `json:"user_agent"`
+	HostHeader             string            `json:"host_header"`
+	HostHeaderKeepOriginal bool              `json:"host_header_keep_original"`
+	UpstreamHashPrefix     string            `json:"upstream_hash_prefix"`
+	TryOtherUpstreamOnCode map[string]string `json:"try_other_upstream_on_code"`
 }
 
 // New returns a configured and ready to use Upstream instance.
@@ -36,11 +38,21 @@ func New(cfg *config.Handler, l *types.Location, next types.RequestHandler) (*Re
 		}
 	}
 
+	var codesToRetry = make(map[int]string, len(s.TryOtherUpstreamOnCode))
+	for code, upstream := range s.TryOtherUpstreamOnCode {
+		intCode, err := strconv.Atoi(code)
+		if err != nil {
+			return nil, fmt.Errorf("handler.proxy[%s]: a status code for retries '%s' couldn't be parsed %s", l.Name, code, err)
+		}
+		codesToRetry[intCode] = upstream
+	}
+
 	//!TODO: record statistics (times, errors, etc.) for all requests
 
 	return &ReverseProxy{
-		Upstream: l.Upstream,
-		Logger:   l.Logger,
-		Settings: s,
+		defaultUpstream: l.Upstream,
+		Logger:          l.Logger,
+		Settings:        s,
+		CodesToRetry:    codesToRetry,
 	}, nil
 }

--- a/types/app_stats.go
+++ b/types/app_stats.go
@@ -18,6 +18,9 @@ type App interface {
 
 	// GetLocationFor returns the Location that mathes the provided host and path
 	GetLocationFor(host, path string) *Location
+
+	// GetUpstream gets an upstream by it's id, nil is returned if no such is defined
+	GetUpstream(id string) Upstream
 }
 
 // AppStats are stats for the whole application


### PR DESCRIPTION
add 'try_other_upstream_on_code' settings that maps returned status code
to upstream to be retried with. The retry is only on the first request.