### PR TITLE
Upstream request will use the original Host header

### DIFF
--- a/handler/proxy/impl.go
+++ b/handler/proxy/impl.go
@@ -79,8 +79,8 @@ func (p *ReverseProxy) getOutRequest(rw http.ResponseWriter, req *http.Request, 
 		return nil, fmt.Errorf("[%p] Proxy handler could not get an upstream address: %v", req, err)
 	}
 	p.Logger.Debugf("[%p] Using upstream %s (%s) to proxy request", req, upAddr, upAddr.OriginalURL)
-	outreq.URL.Scheme = upAddr.Scheme
-	outreq.URL.Host = upAddr.Host
+	outreq.URL.Scheme = upAddr.OriginalURL.Scheme
+	outreq.URL.Host = upAddr.OriginalURL.Host
 
 	// Set the correct host
 	if p.Settings.HostHeader != "" {


### PR DESCRIPTION
Previously, an upstream request was using a Host header
set by the dns resolver. This header was always ip:port. Such a behaviour
is not desirable in the situations where the upstream servers were
configured using a domain name.