### PR TITLE
restrict the amount of HTTP io workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Here you can find all the HTTP-related configurations. The basic config looks li
     "read_timeout": 12312310,
     "write_timeout": 213412314,
     "io_transfer_size": "128k",
+    "io_workers": 4,
     "virtual_hosts": [/*...*/],
 }
 ```
@@ -101,6 +102,8 @@ Description of all the keys and their meaning:
 * `virtual_hosts` (*array*) - Contains the [virtual hosts](#virtual-hosts) of this server. Every virtual host is represented by a object which contains its configuration.
 
 * `io_transfer_size` (*string*) - Bytes size. It tells the size of blocks to be transfered on the network. The timeouts previously mentioned are for pieces this big. Too big of a size might lead to timing out or too excessive memory usage, too small may lead to bad performance due to too many syscalls. The default is '128k'.
+
+* `io_workers` (*int*) - the amount of threads that should to network read|write operations on the client side. This is practically read requests and write response, this does not limit the workers used to read from storages, upstreams and such.
 
 ### Cache Zones
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Description of all the keys and their meaning:
 
 * `io_transfer_size` (*string*) - Bytes size. It tells the size of blocks to be transfered on the network. The timeouts previously mentioned are for pieces this big. Too big of a size might lead to timing out or too excessive memory usage, too small may lead to bad performance due to too many syscalls. The default is '128k'.
 
-* `io_workers` (*int*) - the amount of threads that should to network read|write operations on the client side. This is practically read requests and write response, this does not limit the workers used to read from storages, upstreams and such.
+* `io_workers` (*int*) - the maximum amount of threads that do network read and write operations. This pool is used for read and write operations on the request sockets only. It does not limit the workers used for reading from storages, upstreams and others.
 
 ### Cache Zones
 

--- a/app/app.go
+++ b/app/app.go
@@ -122,7 +122,7 @@ func (a *Application) doServing() {
 // Uses our own listener to make our server stoppable. Similar to
 // net.http.Server.ListenAndServer only this version saves a reference to the listener
 func (a *Application) listenAndServe() error {
-	var deadlineToTimeoutListener = netutils.DeadlineToTimeoutListenerConstructor(int64(a.cfg.HTTP.IOTransferSize))
+	var deadlineToTimeoutListener = netutils.DeadlineToTimeoutListenerConstructor(int64(a.cfg.HTTP.IOTransferSize), a.cfg.HTTP.IOWorkers)
 	// Serve accepts incoming connections on the Listener lsn, creating a
 	// new service goroutine for each.  The service goroutines read requests and
 	// then call the handler (i.e. ServeHTTP() ) to reply to them.

--- a/config/section_http.go
+++ b/config/section_http.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
+	"runtime"
 
 	"github.com/ironsmile/nedomi/types"
 )
@@ -18,6 +19,7 @@ type BaseHTTP struct {
 	Servers        map[string]json.RawMessage `json:"virtual_hosts"`
 	MaxHeadersSize int                        `json:"max_headers_size"`
 	IOTransferSize types.BytesSize            `json:"io_transfer_size"`
+	IOWorkers      int                        `json:"io_workers"`
 	ReadTimeout    uint32                     `json:"read_timeout"`
 	WriteTimeout   uint32                     `json:"write_timeout"`
 
@@ -69,6 +71,9 @@ func (h *HTTP) UnmarshalJSON(buff []byte) error {
 	h.BaseHTTP.Servers = nil   // Cleanup
 	if h.IOTransferSize <= 0 { // set default
 		h.IOTransferSize = defaultIOTranferSize
+	}
+	if h.IOWorkers <= 0 { // set default
+		h.IOWorkers = runtime.NumCPU() / 2
 	}
 	return nil
 }

--- a/utils/netutils/task_pool.go
+++ b/utils/netutils/task_pool.go
@@ -1,0 +1,78 @@
+package netutils
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+)
+
+type task interface {
+	Execute()
+}
+
+type pool struct {
+	mu    sync.Mutex
+	size  int
+	tasks chan task
+	kill  chan struct{}
+	wg    sync.WaitGroup
+}
+
+func newPool(size int) *pool {
+	pool := &pool{
+		tasks: make(chan task, 128),
+		kill:  make(chan struct{}),
+	}
+	fmt.Println(size)
+	pool.resize(size)
+	return pool
+}
+
+func (p *pool) worker() {
+	defer p.wg.Done()
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	for {
+		select {
+		case task, ok := <-p.tasks:
+			if !ok {
+				return
+			}
+			task.Execute()
+		case <-p.kill:
+			return
+		}
+	}
+}
+
+func (p *pool) resize(n int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for p.size < n {
+		p.size++
+		p.wg.Add(1)
+		go p.worker()
+	}
+	for p.size > n {
+		p.size--
+		p.kill <- struct{}{}
+	}
+}
+
+func (p *pool) Close() {
+	close(p.tasks)
+}
+
+func (p *pool) Wait() {
+	p.wg.Wait()
+}
+
+func (p *pool) Exec(task task) {
+	p.tasks <- task
+}
+
+type funcExecute func()
+
+func (f funcExecute) Execute() {
+	f()
+}


### PR DESCRIPTION
The amount of threads that will be reading/writing on incoming
connections (client once) is restricted. This is done by a basic worker
pool by default with NumCPU/2 workers. This can be changed by the new
io_workers setting in the HTTP section.