### PR TITLE
refactor timeoutConn

### DIFF
--- a/utils/copy_n.go
+++ b/utils/copy_n.go
@@ -1,0 +1,18 @@
+package utils
+
+import "io"
+
+// CopyN uses io.CopyN but tries to only have ONE io.LimitReader
+func CopyN(w io.Writer, r io.Reader, limit int64) (n int64, err error) {
+	if lr, ok := r.(*io.LimitedReader); ok {
+		return CopyN(w, lr.R, min64(limit, lr.N))
+	}
+	return io.CopyN(w, r, limit)
+}
+
+func min64(l, r int64) int64 {
+	if l > r {
+		return r
+	}
+	return l
+}


### PR DESCRIPTION
timeoutConn.ReadFrom was way too complicated - now it's a lot simpler.

the new utils.CopyN makes certain that only one io.LimitedReader is
used. This is mostly useful incases where two or more such might get
added one after another leading to sendfile not being used - it can only
get trough one.