### PR TITLE
reimplement throttle handler

### DIFF
--- a/app/connections.go
+++ b/app/connections.go
@@ -1,0 +1,48 @@
+package app
+
+import (
+	"sync"
+
+	"github.com/ironsmile/nedomi/types"
+)
+
+type connections struct {
+	sync.Mutex
+	conns map[string]types.IncomingConn
+}
+
+func newConnections() *connections {
+	return &connections{
+		conns: make(map[string]types.IncomingConn, 50),
+	}
+}
+
+func (c *connections) add(conn types.IncomingConn) {
+	c.Lock()
+	c.conns[conn.RemoteAddr().String()] = conn
+	c.Unlock()
+}
+
+func (c *connections) Size() int {
+	return len(c.conns)
+}
+
+func (c *connections) find(key string) (result types.IncomingConn) {
+	c.Lock()
+	result = c.conns[key]
+	c.Unlock()
+	return
+}
+
+func (c *connections) remove(input types.IncomingConn) {
+	c.Lock()
+	key := input.RemoteAddr().String()
+	// here we check that hte connection is the one that is provided
+	// because there is a posibility for a new connection from the same
+	// remote address to be created and added, before the previous one is
+	// closed(and removed).
+	if conn := c.conns[key]; conn == input {
+		delete(c.conns, key)
+	}
+	c.Unlock()
+}

--- a/app/connections.go
+++ b/app/connections.go
@@ -19,7 +19,7 @@ func newConnections() *connections {
 
 func (c *connections) add(conn types.IncomingConn) {
 	c.Lock()
-	c.conns[conn.RemoteAddr().String()] = conn
+	c.conns[conn.ID()] = conn
 	c.Unlock()
 }
 
@@ -36,12 +36,12 @@ func (c *connections) find(key string) (result types.IncomingConn, ok bool) {
 
 func (c *connections) remove(input types.IncomingConn) {
 	c.Lock()
-	key := input.RemoteAddr().String()
+	key := input.ID()
 	// here we check that hte connection is the one that is provided
 	// because there is a posibility for a new connection from the same
 	// remote address to be created and added, before the previous one is
 	// closed(and removed).
-	if conn := c.conns[key]; conn == input {
+	if conn, ok := c.conns[key]; ok && conn == input {
 		delete(c.conns, key)
 	}
 	c.Unlock()

--- a/app/connections.go
+++ b/app/connections.go
@@ -7,7 +7,7 @@ import (
 )
 
 type connections struct {
-	sync.Mutex
+	sync.RWMutex
 	conns map[string]types.IncomingConn
 }
 
@@ -28,9 +28,9 @@ func (c *connections) Size() int {
 }
 
 func (c *connections) find(key string) (result types.IncomingConn, ok bool) {
-	c.Lock()
+	c.RLock()
 	result, ok = c.conns[key]
-	c.Unlock()
+	c.RUnlock()
 	return
 }
 

--- a/app/connections.go
+++ b/app/connections.go
@@ -27,9 +27,9 @@ func (c *connections) Size() int {
 	return len(c.conns)
 }
 
-func (c *connections) find(key string) (result types.IncomingConn) {
+func (c *connections) find(key string) (result types.IncomingConn, ok bool) {
 	c.Lock()
-	result = c.conns[key]
+	result, ok = c.conns[key]
 	c.Unlock()
 	return
 }

--- a/app/net.go
+++ b/app/net.go
@@ -52,7 +52,7 @@ func (app *Application) ServeHTTP(writer http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	ctx = contexts.NewConnContext(app.ctx, conn)
+	ctx = contexts.NewConnContext(ctx, conn)
 	location.Handler.RequestHandle(ctx, writer, req)
 }
 

--- a/app/net.go
+++ b/app/net.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ironsmile/nedomi/contexts"
 	"github.com/ironsmile/nedomi/types"
+	"github.com/ironsmile/nedomi/utils/httputils"
 )
 
 // GetLocationFor returns the Location that mathes the provided host and path
@@ -29,10 +30,11 @@ func (app *Application) GetLocationFor(host, path string) *types.Location {
 }
 
 func (app *Application) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
-	var reqID = app.newRequestIDFor(app.stats.requested())
-	// new request
-	location := app.GetLocationFor(req.Host, req.URL.Path)
-	var ctx = contexts.NewIDContext(app.ctx, reqID)
+	var (
+		reqID    = app.newRequestIDFor(app.stats.requested())
+		ctx      = contexts.NewIDContext(app.ctx, reqID)
+		location = app.GetLocationFor(req.Host, req.URL.Path)
+	)
 
 	if location == nil || location.Handler == nil {
 		defer app.stats.notConfigured()
@@ -40,19 +42,18 @@ func (app *Application) ServeHTTP(writer http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	var conn = app.conns.find(req.RemoteAddr)
-	if conn == nil { // tough
+	defer app.stats.responded()
+
+	var conn, ok = app.conns.find(req.RemoteAddr)
+	if !ok { // highly unlikely
 		app.logger.Errorf("couldn't find connection for req with addr %s!%s!%s\n",
 			req.RemoteAddr, reqID, req.URL.Path)
+		httputils.Error(writer, http.StatusInternalServerError)
 		return
 	}
-	ctx = contexts.NewConnContext(app.ctx, conn)
 
-	// location matched
-	// stuff before the request is handled
-	defer app.stats.responded()
+	ctx = contexts.NewConnContext(app.ctx, conn)
 	location.Handler.RequestHandle(ctx, writer, req)
-	// after request is handled
 }
 
 func newNotConfiguredHandler() types.RequestHandler {

--- a/app/net.go
+++ b/app/net.go
@@ -39,6 +39,15 @@ func (app *Application) ServeHTTP(writer http.ResponseWriter, req *http.Request)
 		app.notConfiguredHandler.RequestHandle(ctx, writer, req)
 		return
 	}
+
+	var conn = app.conns.find(req.RemoteAddr)
+	if conn == nil { // tough
+		app.logger.Errorf("couldn't find connection for req with addr %s!%s!%s\n",
+			req.RemoteAddr, reqID, req.URL.Path)
+		return
+	}
+	ctx = contexts.NewConnContext(app.ctx, conn)
+
 	// location matched
 	// stuff before the request is handled
 	defer app.stats.responded()

--- a/app/net_test.go
+++ b/app/net_test.go
@@ -112,7 +112,7 @@ func TestLocationMatching(t *testing.T) {
 		req, err := http.NewRequest("GET", url, nil)
 		addr, _ := net.ResolveTCPAddr("tcp", "fromTheTest:1337")
 		req.RemoteAddr = addr.String()
-		app.conns.add(&mockConnection{addr: addr})
+		app.conns.add(&mockConnection{id: req.RemoteAddr})
 		if err != nil {
 			t.Fatalf("Error while creating request - %s", err)
 		}
@@ -139,9 +139,9 @@ func TestLocationMatching(t *testing.T) {
 
 type mockConnection struct {
 	types.IncomingConn
-	addr net.Addr
+	id string
 }
 
-func (m *mockConnection) RemoteAddr() net.Addr {
-	return m.addr
+func (m *mockConnection) ID() string {
+	return m.id
 }

--- a/contexts/connection.go
+++ b/contexts/connection.go
@@ -1,0 +1,23 @@
+package contexts
+
+import (
+	"github.com/ironsmile/nedomi/types"
+	"golang.org/x/net/context"
+)
+
+// The key type is unexported to prevent collisions with context keys defined in
+// other packages.
+type connContextKey int
+
+const connKey connContextKey = 0
+
+// NewConnContext returns a new Context carrying the supplied incoming connection.
+func NewConnContext(ctx context.Context, conn types.IncomingConn) context.Context {
+	return context.WithValue(ctx, connKey, conn)
+}
+
+// GetConn extracts the types.IncomingConnection object, if present.
+func GetConn(ctx context.Context) (types.IncomingConn, bool) {
+	conn, ok := ctx.Value(connKey).(types.IncomingConn)
+	return conn, ok
+}

--- a/handler/throttle/throttle.go
+++ b/handler/throttle/throttle.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ironsmile/nedomi/contexts"
 	"github.com/ironsmile/nedomi/types"
 	"github.com/ironsmile/nedomi/utils"
+	"github.com/ironsmile/nedomi/utils/httputils"
 )
 
 // Configuration is the struct the handler settings will be unmarshalled in
@@ -37,7 +38,11 @@ func New(cfg *config.Handler, l *types.Location, next types.RequestHandler) (typ
 
 	return types.RequestHandlerFunc(
 		func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-			conn, _ := contexts.GetConn(ctx)
+			conn, ok := contexts.GetConn(ctx)
+			if !ok {
+				httputils.Error(w, http.StatusInternalServerError)
+				return
+			}
 			conn.SetThrottle(c.Speed)
 			next.RequestHandle(ctx, w, r)
 		}), nil

--- a/types/incoming_connection.go
+++ b/types/incoming_connection.go
@@ -1,11 +1,9 @@
 package types
 
-import "net"
-
 // IncomingConn is a type that represents incoming connections
 type IncomingConn interface {
 	// see net.Conn.RemoteAddr
-	RemoteAddr() net.Addr
+	ID() string
 	// will throttle the connection at the given speed
 	SetThrottle(speed BytesSize)
 	// stop throttling

--- a/types/incoming_connection.go
+++ b/types/incoming_connection.go
@@ -1,0 +1,13 @@
+package types
+
+import "net"
+
+// IncomingConn is a type that represents incoming connections
+type IncomingConn interface {
+	// see net.Conn.RemoteAddr
+	RemoteAddr() net.Addr
+	// will throttle the connection at the given speed
+	SetThrottle(speed BytesSize)
+	// stop throttling
+	RemoveThrottling()
+}

--- a/utils/netutils/timeout_conn.go
+++ b/utils/netutils/timeout_conn.go
@@ -16,6 +16,7 @@ import (
 // Timeout each read|write on the connection
 type timeoutConn struct {
 	net.Conn
+	id                        string
 	wr                        io.Writer
 	sizeOfTransfer            int64
 	pool                      sync.Pool
@@ -24,7 +25,17 @@ type timeoutConn struct {
 
 // newTimeoutConn returns a timeout conn wrapping around the provided one
 func newTimeoutConn(conn net.Conn, sizeOfTransfer int64, pool sync.Pool) *timeoutConn {
-	return &timeoutConn{Conn: conn, sizeOfTransfer: sizeOfTransfer, pool: pool, wr: conn}
+	return &timeoutConn{
+		Conn:           conn,
+		sizeOfTransfer: sizeOfTransfer,
+		pool:           pool,
+		wr:             conn,
+		id:             conn.RemoteAddr().String(),
+	}
+}
+
+func (tc *timeoutConn) ID() string {
+	return tc.id
 }
 
 // !TODO conform to maxSizeOfTransfer

--- a/utils/throttle/min_max.go
+++ b/utils/throttle/min_max.go
@@ -1,0 +1,24 @@
+package throttle
+
+import "time"
+
+func min64(l, r int64) int64 {
+	if l > r {
+		return r
+	}
+	return l
+}
+
+func max64(l, r int64) int64 {
+	if l > r {
+		return l
+	}
+	return r
+}
+
+func maxDur(l, r time.Duration) time.Duration {
+	if l > r {
+		return l
+	}
+	return r
+}

--- a/utils/throttle/throttled_writer.go
+++ b/utils/throttle/throttled_writer.go
@@ -1,0 +1,103 @@
+package throttle
+
+import (
+	"io"
+	"math"
+	"runtime"
+	"time"
+)
+
+const (
+	minSleep = 10 * time.Millisecond
+)
+
+// ThrottledWriter is a writer that throttles what it writes
+// it also implements io.ReaderFrom
+type ThrottledWriter struct {
+	io.Writer
+	speed, written int64
+	minWrite       int64
+	startTime      time.Time
+	now            func() time.Time
+	sleep          func(time.Duration)
+}
+
+// NewThrottleWriter creates a new throttledWriter writing in the provided io.Writer
+// speed is the desired speed, while min and max Writes is the minimum or max writes that will be
+// made at a time to the underlying writer.
+// Notice: if minWrite is bigger than speed it will become equal to it.
+func NewThrottleWriter(w io.Writer, speed, minWrite int64) *ThrottledWriter {
+	return &ThrottledWriter{
+		Writer:   w,
+		speed:    speed,
+		minWrite: min64(speed, minWrite),
+		now:      time.Now,             // TODO: try to cache it each 10 milliseconds ?
+		sleep:    sleepWithPooledTimer, // TODO: provide a way to change it
+	}
+}
+
+func (tw *ThrottledWriter) Write(b []byte) (n int, err error) {
+	if tw.startTime.IsZero() {
+		tw.startTime = tw.now()
+	}
+	for nn := 0; n < len(b) && err == nil; n += nn {
+		var toWrite = min64(int64(n)+tw.howMuchCanIWrite(), int64(len(b)))
+		nn, err = tw.Writer.Write(b[n:toWrite])
+		tw.written += int64(nn)
+		if err == nil && int64(nn) != (toWrite-int64(n)) {
+			err = io.ErrShortWrite
+		}
+	}
+	return
+}
+
+// ReadFrom reads from the provided io.Reader while respecting the throttling
+func (tw *ThrottledWriter) ReadFrom(r io.Reader) (n int64, err error) {
+	if tw.startTime.IsZero() {
+		tw.startTime = tw.now()
+	}
+	var max int64 = math.MaxInt64
+	var lr = io.LimitReader(r, 0).(*io.LimitedReader)
+	if llr, ok := lr.R.(*io.LimitedReader); ok {
+		max = llr.N
+		lr.R = llr.R
+	}
+	for nn := int64(-1); nn != 0 && err == nil; n += nn {
+		lr.N = min64(tw.howMuchCanIWrite(), max)
+		nn, err = io.Copy(tw.Writer, lr)
+		tw.written += int64(nn)
+	}
+	if err == io.EOF {
+		err = nil
+	}
+	return
+}
+
+func (tw *ThrottledWriter) canWriteRightNow() int64 {
+	var timePassed = tw.now().Sub(tw.startTime).Nanoseconds() /
+		int64(time.Second) // in seconds
+	return timePassed*tw.speed - tw.written
+}
+
+func (tw *ThrottledWriter) waitAtleastMinWrite() int64 {
+	runtime.Gosched()
+	var toWriteRightNow = tw.canWriteRightNow()
+	if toWriteRightNow >= tw.minWrite {
+		return toWriteRightNow
+	}
+	calculatedSleep := time.Duration((tw.minWrite-toWriteRightNow)/tw.speed) * time.Second
+	tw.sleep(maxDur(calculatedSleep, minSleep))
+	// canWriteRightNow may return less than minWrite if minWrite is small enough and the speed
+	// is big enough but we have slept long enough for atleast a minWrite so if it's less than
+	// we write minWrite.
+	return max64(tw.canWriteRightNow(), tw.minWrite)
+}
+
+func (tw *ThrottledWriter) howMuchCanIWrite() int64 {
+	var toWriteRightNow = tw.canWriteRightNow()
+	if toWriteRightNow >= tw.minWrite {
+		return toWriteRightNow
+	}
+
+	return tw.waitAtleastMinWrite()
+}

--- a/utils/throttle/throttled_writer_bench_test.go
+++ b/utils/throttle/throttled_writer_bench_test.go
@@ -1,0 +1,38 @@
+package throttle
+
+import "testing"
+
+func BenchmarkThrottledWriterWithReadFrom(b *testing.B) {
+	benchInParallel(b, testResponseWriterWithReadFrom)
+}
+
+func BenchmarkThrottledWriter(b *testing.B) {
+	benchInParallel(b, testResponseWriter)
+}
+
+func benchInParallel(b *testing.B, f testFunc) {
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			runInParallel(b, benchTests[:], f)
+		}
+	})
+}
+
+var benchTestsPre = []throttleTest{
+	{"20M with 5MB/s", content["20M"], 5 * 1024 * 1024}, // 4 seconds
+	// {content["2M"], 200 * 1024},       // 10 seconds
+	{"2M with 1MB/s", content["2M"], 1024 * 1024},       // 2 seconds
+	{"10K with 5MB/s", content["10K"], 5 * 1024 * 1024}, // 2 seconds
+	//{content["10K"], 1024 * 1024},     // 10 seconds
+	//{content["1K"], 100},              // 10+ seconds
+}
+
+var benchTests = func(tests []throttleTest, repeat int) []throttleTest {
+	var result = make([]throttleTest, repeat*len(tests))
+	for i := 0; repeat > i; i++ {
+		copy(result[i*len(tests):], tests)
+	}
+
+	return result
+}(benchTestsPre, 10) // LOAD

--- a/utils/throttle/throttled_writer_test.go
+++ b/utils/throttle/throttled_writer_test.go
@@ -1,0 +1,174 @@
+package throttle
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+const (
+	testMinWrite = 8 * 1024
+)
+
+type testFunc func(testing.TB, throttleTest)
+
+var content = map[string][]byte{
+	"20M": generate(1024 * 1024 * 20),
+	"2M":  generate(1024 * 1024 * 2),
+	"10K": generate(1024 * 10),
+	"1K":  generate(1024),
+}
+
+func generate(n int64) []byte {
+	var result = make([]byte, n)
+	var r = rand.New(rand.NewSource(n))
+	for i := int64(0); n > i+8; i++ {
+		binary.BigEndian.PutUint64(result[i:], uint64(r.Int63()))
+	}
+	return result
+}
+
+type throttleTest struct {
+	info  string
+	data  []byte
+	speed int64
+}
+
+var tests = [...]throttleTest{
+	{"20M with 1MB/s", content["20M"], 1024 * 1024},
+	{"2M with 200KB/s", content["2M"], 200 * 1024},
+	{"2M with 1MB/s", content["2M"], 1024 * 1024},
+	{"10K with 1MB/s", content["10K"], 1024 * 1024},
+	{"1K with 100B/s", content["1K"], 100},
+}
+
+func TestResponseWriter(t *testing.T) {
+	t.Parallel()
+	runInParallel(t, tests[:], testResponseWriter)
+}
+
+func testResponseWriter(t testing.TB, test throttleTest) {
+	var ew = &expectantWriter{expects: test.data}
+	var tw = NewThrottleWriter(ew, test.speed, testMinWrite)
+	testCopy(t, tw, bytes.NewReader(test.data), int64(len(test.data)), test.speed, test.info)
+}
+
+func TestResponseWriterWithReadFrom(t *testing.T) {
+	t.Parallel()
+	runInParallel(t, tests[:], testResponseWriterWithReadFrom)
+}
+
+func testResponseWriterWithReadFrom(t testing.TB, test throttleTest) {
+	var ew = &expectantWriter{expects: test.data}
+	var tw = NewThrottleWriter(ew, test.speed, testMinWrite)
+	testCopy(t, tw,
+		reader{bytes.NewReader(test.data)},
+		int64(len(test.data)),
+		test.speed,
+		test.info,
+	)
+}
+
+func runInParallel(t testing.TB, tests []throttleTest, testIt testFunc) {
+	var chs []chan struct{}
+	for _, test := range tests {
+		var ch = make(chan struct{})
+		chs = append(chs, ch)
+		go func(test throttleTest) {
+			defer close(ch)
+			testIt(t, test)
+		}(test)
+	}
+	for _, ch := range chs {
+		<-ch
+	}
+}
+
+func around(l, r time.Duration) bool {
+	var ln, rn = l.Nanoseconds(), r.Nanoseconds()
+	var div = abs(ln - rn)
+	return ln/10 > div || rn/10 > div || int64(time.Second/2) > div
+}
+
+func abs(a int64) int64 {
+	if a > 0 {
+		return a
+	}
+	return -a
+}
+
+type expectantWriter struct {
+	expects []byte
+	n       int
+}
+
+func (e *expectantWriter) Write(b []byte) (n int, err error) {
+	for _, aByte := range b {
+		if e.expects[e.n] != aByte {
+			return n, fmt.Errorf(
+				"the %dth symbol was supposed to be %c but was %c",
+				e.n, e.expects[e.n], aByte)
+		}
+		e.n++
+		n++
+	}
+	return n, nil
+}
+
+type reader struct {
+	io.Reader
+}
+
+type expectantReaderFrom struct {
+	expects []byte
+	n       int64
+}
+
+func (e *expectantReaderFrom) ReadFrom(r io.Reader) (n int64, err error) {
+	var b = make([]byte, 1024)
+	var nn = 0
+	for ; err == nil; n += int64(nn) {
+		nn, err = r.Read(b[:])
+		for _, aByte := range b[:nn] {
+			if e.expects[e.n] != aByte {
+				return n, fmt.Errorf(
+					"the %dth symbol was supposed to be %c but was %c",
+					e.n, e.expects[e.n], aByte)
+			}
+			e.n++
+		}
+	}
+	if err == io.EOF {
+		err = nil
+	}
+	return
+}
+
+func testCopy(
+	t testing.TB,
+	w io.Writer,
+	r io.Reader,
+	expectedSize, expectedSpeed int64,
+	info string,
+) {
+	now := time.Now()
+	n, err := io.Copy(w, r)
+	end := time.Now()
+	if err != nil {
+		t.Fatalf("[%s]unexpected error from io.Copy :%s", info, err)
+	}
+	if n != expectedSize {
+		t.Errorf("[%s]the expected size of copy was %d but it was %d",
+			info, expectedSize, n)
+	}
+	got := end.Sub(now)
+	expected := time.Duration((n / expectedSpeed)) * time.Second
+	if !around(got, expected) {
+		t.Errorf("[%s]the throttledWriting took %s which isn't around %s",
+			info, got, expected)
+	}
+}

--- a/utils/throttle/throttled_writer_test.go
+++ b/utils/throttle/throttled_writer_test.go
@@ -47,7 +47,6 @@ var tests = [...]throttleTest{
 }
 
 func TestResponseWriter(t *testing.T) {
-	t.Parallel()
 	runInParallel(t, tests[:], testResponseWriter)
 }
 
@@ -58,7 +57,6 @@ func testResponseWriter(t testing.TB, test throttleTest) {
 }
 
 func TestResponseWriterWithReadFrom(t *testing.T) {
-	t.Parallel()
 	runInParallel(t, tests[:], testResponseWriterWithReadFrom)
 }
 
@@ -91,7 +89,7 @@ func runInParallel(t testing.TB, tests []throttleTest, testIt testFunc) {
 func around(l, r time.Duration) bool {
 	var ln, rn = l.Nanoseconds(), r.Nanoseconds()
 	var div = abs(ln - rn)
-	return ln/10 > div || rn/10 > div || int64(time.Second/2) > div
+	return ln/8 > div || rn/8 > div || int64(time.Second/2) > div
 }
 
 func abs(a int64) int64 {

--- a/utils/throttle/timers.go
+++ b/utils/throttle/timers.go
@@ -1,0 +1,19 @@
+package throttle
+
+import (
+	"sync"
+	"time"
+)
+
+var timerPool = sync.Pool{
+	New: func() interface{} {
+		return time.NewTimer(time.Hour * 1000)
+	},
+}
+
+func sleepWithPooledTimer(d time.Duration) {
+	timer := timerPool.Get().(*time.Timer)
+	timer.Reset(d)
+	<-timer.C
+	timerPool.Put(timer)
+}

--- a/utils/throttle/timers_test.go
+++ b/utils/throttle/timers_test.go
@@ -1,0 +1,63 @@
+package throttle
+
+import (
+	"testing"
+	"time"
+)
+
+const (
+	sleepTime         = time.Millisecond * 50
+	fastWait          = time.Millisecond * 30
+	slowWait          = time.Millisecond * 30
+	parallelSleeps    = 20
+	sleepsInGoroutine = 100
+)
+
+func TestSleepWithPooledTimer(t *testing.T) {
+	for i := 0; sleepsInGoroutine > i; i++ {
+		var ch = sleepFor(sleepTime)
+		select {
+		case <-ch:
+			t.Fatalf("sleep was too fast %d", i)
+		case <-time.After(fastWait):
+			// all is fine in this world
+		}
+		select {
+		case <-ch:
+			// all is fine in this world
+		case <-time.After(slowWait):
+			t.Fatalf("sleep was too slow %d", i)
+		}
+	}
+}
+
+func TestParallelSleepWithPooledTimer(t *testing.T) {
+	var wg = make(chan struct{}, parallelSleeps)
+
+	for i := 0; parallelSleeps > i; i++ {
+		go func(i int) {
+			TestSleepWithPooledTimer(t)
+			wg <- struct{}{}
+		}(i)
+	}
+
+	for i := 0; parallelSleeps > i && !t.Failed(); i++ {
+		<-wg
+	}
+}
+
+func sleepFor(d time.Duration) <-chan struct{} {
+	var ch = make(chan struct{})
+	go func() {
+		sleepWithPooledTimer(d)
+		sendStructForASecond(ch, d*2)
+	}()
+	return ch
+}
+
+func sendStructForASecond(ch chan struct{}, d time.Duration) {
+	select {
+	case ch <- struct{}{}:
+	case <-time.After(d):
+	}
+}


### PR DESCRIPTION
the throttle handler reimplementation has one main strenght - it can use
sendfile. Other benifits is that it removes a dependancy. I would also
argue it's lighter runtime(don't quote me).

In order to use this we use the now new ThrottledWriter which records
how much bytes it has throttled at a given speed and tries to write as
much as it can in order to get to the speed that is requested.

The reason why it's done in the timeoutConn instead of in the handler
given that it requires the whole getting the correct connection for each
request is:
http.ResponseWriter.ReadFrom does os.Stat on each io.LimitedReader it
gets. This adds up pretty quickly to hundred of thousands of os.Stat, which
both slow down the whole application, and make a lot of objects.

Given the fact that io.LimitedReader is the only way to limit the amount
of data the sendfile sends at a time and there is no way to go around
http.ResponseWriter.ReadFrom without Hijacking the connection, the
current solution emerged.

Additional benifit is that other handlers can now throttle as well.