### PR TITLE
split io_transfer_size in min and max settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Here you can find all the HTTP-related configurations. The basic config looks li
     "max_headers_size": 1231241212,
     "read_timeout": 12312310,
     "write_timeout": 213412314,
-    "io_transfer_size": "128k",
+    "max_io_transfer_size": "1m",
+    "min_io_transfer_size": "128k",
     "virtual_hosts": [/*...*/],
 }
 ```
@@ -102,7 +103,9 @@ Description of all the keys and their meaning:
 
 * `virtual_hosts` (*array*) - Contains the [virtual hosts](#virtual-hosts) of this server. Every virtual host is represented by a object which contains its configuration.
 
-* `io_transfer_size` (*string*) - Bytes size. It tells the size of blocks to be transfered on the network. The timeouts previously mentioned are for pieces this big. Too big of a size might lead to timing out or too excessive memory usage, too small may lead to bad performance due to too many syscalls. The default is '128k'.
+* `max_io_transfer_size` (*string*) - Bytes size. It tells the maximum size of blocks to be transfered on the network. The timeouts previously mentioned are for pieces at most this big. Too big of a size might lead to timing out or too excessive memory usage, too small may lead to bad performance due to too many syscalls. If no throttling is used this will be the size of all writes/sendfiles. The default is '1m'.
+
+* `min_io_transfer_size` (*string*) - Bytes size. It tells the minimum size of blocks to be transfered on the network. This number has no meaning when throttling isn't used. Even then it might be ignored if the throttle speed per second is less than it. In that case the minimum size becomes the speed for the connection that is throttled. The default is '128k'.
 
 ### Cache Zones
 

--- a/app/app.go
+++ b/app/app.go
@@ -134,7 +134,10 @@ func (a *Application) doServing() {
 // Uses our own listener to make our server stoppable. Similar to
 // net.http.Server.ListenAndServer only this version saves a reference to the listener
 func (a *Application) listenAndServe() error {
-	var deadlineToTimeoutListener = netutils.DeadlineToTimeoutListenerConstructor(int64(a.cfg.HTTP.IOTransferSize))
+	var deadlineToTimeoutListener = netutils.DeadlineToTimeoutListenerConstructor(
+		int64(a.cfg.HTTP.MaxIOTransferSize),
+		int64(a.cfg.HTTP.MinIOTransferSize),
+	)
 	// Serve accepts incoming connections on the Listener lsn, creating a
 	// new service goroutine for each.  The service goroutines read requests and
 	// then call the handler (i.e. ServeHTTP() ) to reply to them.

--- a/app/reload.go
+++ b/app/reload.go
@@ -8,11 +8,12 @@ import (
 )
 
 var (
-	errCfgIsNil                   = errors.New("no config was provided for the reload")
-	errCfgUserIsDifferent         = errors.New("can't change user by reload")
-	errCfgWorkDirIsDifferent      = errors.New("can't change workdir by reload")
-	errCfgListenIsDifferent       = errors.New("can't change addressed being listened to by reload")
-	errCfgTransferSizeIsDifferent = errors.New("can't change io_transfer_size by reload")
+	errCfgIsNil                      = errors.New("no config was provided for the reload")
+	errCfgUserIsDifferent            = errors.New("can't change user by reload")
+	errCfgWorkDirIsDifferent         = errors.New("can't change workdir by reload")
+	errCfgListenIsDifferent          = errors.New("can't change addressed being listened to by reload")
+	errCfgMaxTransferSizeIsDifferent = errors.New("can't change max_io_transfer_size by reload")
+	errCfgMinTransferSizeIsDifferent = errors.New("can't change min_io_transfer_size by reload")
 
 	errTmplDifferentType      = "different types for same id '%s' between configs"
 	errTmplDifferentPath      = "different paths for same id '%s' between configs"
@@ -36,8 +37,11 @@ func (a *Application) checkConfigCouldBeReloaded(cfg *config.Config) error {
 	if a.cfg.HTTP.Listen != cfg.HTTP.Listen {
 		return errCfgListenIsDifferent
 	}
-	if a.cfg.HTTP.IOTransferSize != cfg.HTTP.IOTransferSize {
-		return errCfgTransferSizeIsDifferent
+	if a.cfg.HTTP.MaxIOTransferSize != cfg.HTTP.MaxIOTransferSize {
+		return errCfgMaxTransferSizeIsDifferent
+	}
+	if a.cfg.HTTP.MinIOTransferSize != cfg.HTTP.MinIOTransferSize {
+		return errCfgMinTransferSizeIsDifferent
 	}
 
 	return cacheZonesAreCompatible(a.cfg.CacheZones, cfg.CacheZones)

--- a/app/reload_test.go
+++ b/app/reload_test.go
@@ -344,8 +344,8 @@ func TestCheckConfigCouldBeReloaded(t *testing.T) {
 			},
 			HTTP: &config.HTTP{
 				BaseHTTP: config.BaseHTTP{
-					Listen:         ":8282",
-					IOTransferSize: 43,
+					Listen:            ":8282",
+					MaxIOTransferSize: 43,
 				},
 			},
 		},
@@ -359,12 +359,46 @@ func TestCheckConfigCouldBeReloaded(t *testing.T) {
 			},
 			HTTP: &config.HTTP{
 				BaseHTTP: config.BaseHTTP{
-					Listen:         ":8282",
-					IOTransferSize: 42,
+					Listen:            ":8282",
+					MaxIOTransferSize: 42,
 				},
 			},
 		},
-		err: errCfgTransferSizeIsDifferent,
+		err: errCfgMaxTransferSizeIsDifferent,
+	}, {
+		cfg1: &config.Config{
+			BaseConfig: config.BaseConfig{
+				System: config.System{
+					Pidfile: "/path/to/pid/file",
+					Workdir: "/path/to/work/dir",
+					User:    "user",
+				},
+			},
+			HTTP: &config.HTTP{
+				BaseHTTP: config.BaseHTTP{
+					Listen:            ":8282",
+					MaxIOTransferSize: 43,
+					MinIOTransferSize: 43,
+				},
+			},
+		},
+		cfg2: &config.Config{
+			BaseConfig: config.BaseConfig{
+				System: config.System{
+					Pidfile: "/path/to/pid/file",
+					Workdir: "/path/to/work/dir",
+					User:    "user",
+				},
+			},
+			HTTP: &config.HTTP{
+				BaseHTTP: config.BaseHTTP{
+					Listen:            ":8282",
+					MaxIOTransferSize: 43,
+					MinIOTransferSize: 42,
+				},
+			},
+		},
+		err: errCfgMinTransferSizeIsDifferent,
 	}}
 
 	for _, test := range tests {

--- a/config/section_http.go
+++ b/config/section_http.go
@@ -8,18 +8,20 @@ import (
 	"github.com/ironsmile/nedomi/types"
 )
 
-const defaultIOTranferSize = 128 * 1024
+const defaultMaxIOTranferSize = 1024 * 1024 // 1m
+const defaultMinIOTranferSize = 1024 * 128  // 128k
 
 // BaseHTTP contains the basic configuration options for HTTP.
 type BaseHTTP struct {
 	HeadersRewrite
-	Listen         string                     `json:"listen"`
-	Upstreams      map[string]json.RawMessage `json:"upstreams"`
-	Servers        map[string]json.RawMessage `json:"virtual_hosts"`
-	MaxHeadersSize int                        `json:"max_headers_size"`
-	IOTransferSize types.BytesSize            `json:"io_transfer_size"`
-	ReadTimeout    uint32                     `json:"read_timeout"`
-	WriteTimeout   uint32                     `json:"write_timeout"`
+	Listen            string                     `json:"listen"`
+	Upstreams         map[string]json.RawMessage `json:"upstreams"`
+	Servers           map[string]json.RawMessage `json:"virtual_hosts"`
+	MaxHeadersSize    int                        `json:"max_headers_size"`
+	MinIOTransferSize types.BytesSize            `json:"min_io_transfer_size"`
+	MaxIOTransferSize types.BytesSize            `json:"max_io_transfer_size"`
+	ReadTimeout       uint32                     `json:"read_timeout"`
+	WriteTimeout      uint32                     `json:"write_timeout"`
 
 	// Defaults for vhosts:
 	DefaultHandlers  []Handler `json:"default_handlers"`
@@ -62,9 +64,12 @@ func (h *HTTP) UnmarshalJSON(buff []byte) error {
 		h.Servers = append(h.Servers, &vhost)
 	}
 
-	h.BaseHTTP.Servers = nil   // Cleanup
-	if h.IOTransferSize <= 0 { // set default
-		h.IOTransferSize = defaultIOTranferSize
+	h.BaseHTTP.Servers = nil      // Cleanup
+	if h.MaxIOTransferSize <= 0 { // set default
+		h.MaxIOTransferSize = defaultMaxIOTranferSize
+	}
+	if h.MinIOTransferSize <= 0 { // set default
+		h.MinIOTransferSize = defaultMinIOTranferSize
 	}
 	return nil
 }


### PR DESCRIPTION
the new min will be used when throttling, to prevent writing in very
small pieces, doing a lot of syscalls.