### PR TITLE
Git vars can be overriden wint env vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@
 BINARY=nedomi
 SOURCES := $(shell find . -name '*.go')
 
-VERSION=$(shell cat VERSION)
-BUILD_TIME=$(shell date +%s)
-GIT_HASH=$(shell git show --pretty=%h -s HEAD)
-GIT_TAG=$(shell git name-rev --tags --no-undefined --name-only HEAD 2>/dev/null)
-GIT_STATUS := $(shell git status --porcelain -uno)
+VERSION = $(shell cat VERSION)
+BUILD_TIME = $(shell date +%s)
+GIT_HASH ?= $(shell git show --pretty=%h -s HEAD)
+GIT_TAG ?= $(shell git name-rev --tags --no-undefined --name-only HEAD 2>/dev/null)
+GIT_STATUS ?= $(shell git status --porcelain -uno)
 ifneq "$(GIT_STATUS)" ""
 	DIRTY:=true
 endif


### PR DESCRIPTION
If you are building in a gitless directory the git commands will
fail. This may be because you are building from a source archive.

This commit gives you the option to supply the variables
manually via environment variables:

    $ GIT_TAG="v0.1.2" make

This does not solve the problem completely since ideally,
you should be able to just type `make` and compile nedomi
without warnings.