### PR TITLE
Remove whitespaces while reading PID file contents

### DIFF
--- a/app/env.go
+++ b/app/env.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/ironsmile/nedomi/config"
@@ -71,7 +72,7 @@ func CleanupEnv(cfg *config.Config) error {
 		return err
 	}
 	var pid int
-	pid, err = strconv.Atoi(string(b))
+	pid, err = strconv.Atoi(strings.TrimSpace(string(b)))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
An unexpected white space in the PID file was causing an error
message on shutdown. Such an whitespace is easy to slip into
the file. For example `echo 123 > nedomi.pid` will add a
new line. Situations like this shouldn't be a cause for alarm.