### PR TITLE
storage.scheduler: get a reloadable logger - fixes leaking loggers

### DIFF
--- a/handler/cache/handler_helpers.go
+++ b/handler/cache/handler_helpers.go
@@ -125,7 +125,7 @@ func (h *reqHandler) getResponseHook() func(*httputils.FlexibleResponseWriter) {
 		h.Logger.Debugf("[%s] Setting the cached data to expire in %s", h.reqID, expiresIn)
 		h.Cache.Scheduler.AddEvent(
 			h.objID.Hash(),
-			storage.GetExpirationHandler(h.Cache, h.Logger, h.objID),
+			storage.GetExpirationHandler(h.Cache, h.objID),
 			expiresIn,
 		)
 	}

--- a/storage/utils.go
+++ b/storage/utils.go
@@ -4,8 +4,8 @@ import "github.com/ironsmile/nedomi/types"
 
 // GetExpirationHandler returns a potentially long-lived callback that removes
 // the specified object from the storage.
-func GetExpirationHandler(cz *types.CacheZone, logger types.Logger, id *types.ObjectID) func() {
-	return func() {
+func GetExpirationHandler(cz *types.CacheZone, id *types.ObjectID) func(types.Logger) {
+	return func(logger types.Logger) {
 		//!TODO: simplify and ignore the cache algorithm when expiring objects.
 		// It is only supposed to take into account client interest in the
 		// object parts, not whether they are expired due to upstream timeouts

--- a/types/scheduler.go
+++ b/types/scheduler.go
@@ -5,10 +5,14 @@ import "time"
 // Scheduler efficiently manages and executes callbacks at specified times.
 type Scheduler interface {
 	// AddEvent schedules the passed callback to be executed at the supplied time.
-	AddEvent(key ObjectIDHash, callback func(), in time.Duration)
+	AddEvent(key ObjectIDHash, callback ScheduledCallback, in time.Duration)
 
 	// Contains checks whether an event with the supplied key is scheduled.
 	Contains(key ObjectIDHash) bool
 
-	//!TODO: expose the other methods of the current scheduler implementation.
+	// ChangeConfig change configs of the scheduler and start using them
+	ChangeConfig(Logger)
 }
+
+// ScheduledCallback is the type of the function that Scheduler will callback when scheduled
+type ScheduledCallback func(Logger)


### PR DESCRIPTION
previously the scheduler did not have a logger and scheduled functions
that wanted to log something (storage.GetExpirationHandler) had to bring
one with them.

This has unfortunate side effect that while the function is scheduled
the logger can't be freed.

But when reloading the loggers are closed and than reopened. This is
done so that the files can be logrotated/changed.

If a file is scheduled to be deleted in a week, the logger will not be
GCed, for a week, and as such the fd to the log file will not be closed.