### PR TITLE
handler.dir: gets `strip` setting

### DIFF
--- a/handler/dir/dir.go
+++ b/handler/dir/dir.go
@@ -14,14 +14,15 @@ import (
 // New creates and returns a ready to used ServerStatusHandler.
 func New(cfg *config.Handler, l *types.Location, next types.RequestHandler) (types.RequestHandler, error) {
 	var s struct {
-		Root string `json:"root"`
+		Root  string `json:"root"`
+		Strip string `json:"strip"`
 	}
 	if err := json.Unmarshal(cfg.Settings, &s); err != nil {
 		return nil, fmt.Errorf("dir handler: error while parsing settings - %s", err)
 	}
 
-	fs := http.FileServer(http.Dir(s.Root))
-	return types.RequestHandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-		fs.ServeHTTP(w, r)
+	h := http.StripPrefix(s.Strip, http.FileServer(http.Dir(s.Root)))
+	return types.RequestHandlerFunc(func(_ context.Context, w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(w, r)
 	}), nil
 }


### PR DESCRIPTION
this is mostly useful(and semi required) when the dir handler is used in
a location with a path different from `/` for example `/doc`.
Without it a request `/var/www/index.html` (with dir handler with `root`
`/var/www`) will try to serve file with path `/var/www/doc/index.html`.

To fix this the new `strip` setting was added. It will strip a provided
path from the beginning of the requested path.

Setting it to `/doc` in the above example will give the (expected)
result of serving `/var/www/index.html`.